### PR TITLE
Upstream development for prpl Foundation (asynchronous DHCPv6 handling, ubus backend, statistics, reconfiguration, ...)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(${EXT_CER_ID})
 	add_definitions(-DEXT_CER_ID=${EXT_CER_ID})
 endif(${EXT_CER_ID})
 
-set(SOURCES src/odhcp6c.c src/dhcpv6.c src/ra.c src/script.c)
+set(SOURCES src/odhcp6c.c src/dhcpv6.c src/ra.c src/script.c src/config.c)
 
 set(LIBRARIES resolv)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,18 @@ set(SOURCES src/odhcp6c.c src/dhcpv6.c src/ra.c src/script.c)
 
 set(LIBRARIES resolv)
 
+option(ENABLE_UBUS "Enable support for ubus" OFF)
+
+if(ENABLE_UBUS)
+	set(USE_LIBUBOX 1)
+	add_definitions(-DHAVE_UBUS)
+	set(SOURCES ${SOURCES} src/ubus.c)
+	FIND_LIBRARY(ubus_lib NAMES ubus)
+	set(LIBRARIES ${LIBRARIES} ${ubus_lib})
+	FIND_PATH(ubus_include_dir NAMES libubus.h)
+	INCLUDE_DIRECTORIES(${ubus_include_dir})
+endif()
+
 if(USE_LIBUBOX)
 	add_definitions(-DUSE_LIBUBOX)
 	set(LIBRARIES ${LIBRARIES} ubox)

--- a/README
+++ b/README
@@ -85,3 +85,45 @@ Environment:
 * RA_RETRANSMIT	ND Retransmit time
 * AFTR			The DS-Lite AFTR domain name
 * MAPE / MAPT / LW4O6	Softwire rules for MAPE, MAPT and LW4O6
+
+** Ubus Integration **
+
+Build with ENABLE_UBUS flag to connect odhcp6c to ubus. Object is registered at : "odhcp6c.{ifname}."
+
+Events are emitted whenever the DHCPv6 state changes and can replace the use of a state script. The variables are the same as those defined in the State Script section.
+
+The following RPC methods are available:
+
+* *get_state()* : Returns the DHCPv6 state
+	- OUT : see State Script section
+* *get_statistics()* : Returns the packet statistics 
+	- OUT :
+		- *dhcp_solicit* : Total number of SOLICIT messages sent
+		- *dhcp_advertise* : Total number of ADVERTISE messages received
+		- *dhcp_request* : Total number of REQUEST messages sent
+		- *dhcp_confirm* : Total number of CONFIRM messages sent
+		- *dhcp_renew* : Total number of RENEW messages sent
+		- *dhcp_rebind* : Total number of REBIND messages sent
+		- *dhcp_reply* : Total number of REPLY messages received
+		- *dhcp_release* : Total number of RELEASE messages sent
+		- *dhcp_decline* : Total number of DECLINE messages sent
+		- *dhcp_reconfigure* : Total number of RECONFIGURE messages received
+		- *dhcp_information_request* : Total number of INFORMATION-REQUEST messages sent
+		- *dhcp_discarded_packets* : Total number of discarded DHCP packets 
+		- *dhcp_transmit_failures* : Total number of DHCP messages that failed to be transmitted
+* *reset_statistics()* : Reset packet statistics
+* *reconfigure_dhcp(IN)* : Reconfigure DHCP settings
+	- IN (optional):
+		- *dscp* (int) : DSCP value used for DHCP packets
+		- *release* (bool) : Send a RELEASE message on exit/reset
+		- *sol_timeout* (int) : Maximum timeout for DHCPv6-SOLICIT
+		- *sk_prio* (int) : Packet kernel priority
+		- *opt_requested* (int[]) : Options to be requested
+		- *opt_strict* (bool) : Do not request any options except those specified
+		- *opt_reconfigure* (bool) : Send Accept Reconfigure option
+		- *opt_fqdn* (bool) : Send Client FQDN option
+		- *opt_unicast* (bool) : Ignore Server Unicast option
+		- *opt_send* (string[]) : Options to be sent
+		- *req_addresses* (string{try|force|none}) : Request addresses 
+		- *req_prefixes* (int) : Request Prefixes (0 = auto)
+		- *stateful_only* (bool) : Discard advertisements without any address or prefix proposed

--- a/README
+++ b/README
@@ -116,7 +116,6 @@ The following RPC methods are available:
 	- IN (optional):
 		- *dscp* (int) : DSCP value used for DHCP packets
 		- *release* (bool) : Send a RELEASE message on exit/reset
-		- *sol_timeout* (int) : Maximum timeout for DHCPv6-SOLICIT
 		- *sk_prio* (int) : Packet kernel priority
 		- *opt_requested* (int[]) : Options to be requested
 		- *opt_strict* (bool) : Do not request any options except those specified
@@ -127,3 +126,23 @@ The following RPC methods are available:
 		- *req_addresses* (string{try|force|none}) : Request addresses 
 		- *req_prefixes* (int) : Request Prefixes (0 = auto)
 		- *stateful_only* (bool) : Discard advertisements without any address or prefix proposed
+		- *irt_default* (int) :  Default information refresh time (expressed in seconds)
+		- *irt_min* (int) : Minimum information refresh time (expressed in seconds)
+		- *rand_factor* (int) : Randomization factor for retransmission timeout
+		- *msg_solicit* (table) : Retransmission settings for SOLICIT
+		- *msg_request* (table) : Retransmission settings for REQUEST
+		- *msg_renew* (table) : Retransmission settings for RENEW
+		- *msg_rebind* (table) : Retransmission settings for REBIND
+		- *msg_release* (table) : Retransmission settings for RELEASE
+		- *msg_decline* (table) : Retransmission settings for DECLINE
+		- *msg_inforeq* (table) : Retransmission settings for INFORMATION-REQUEST
+		- *auth_protocol* (string) : Authentication protocol to be used ("None","ConfigurationToken", "ReconfigureKeyAuthentication")
+		- *auth_token* (string) : Authentication token to be used when AuthenticationProtocol is set to ConfigurationToken
+* *renew()* : Force transmission of RENEW/INFORMATION-REQUEST messages
+* *release()* : Force transmission of RELEASE message and start new cycle
+
+Input arguments for retransmission settings :
+	- *delay_max* (int) : Maximum delay of first message (expressed in seconds)
+	- *timeout_init* (int) : Initial message timeout (expressed in seconds)
+	- *timeout_max* (int) : Initial message timeout (expressed in seconds)
+	- *rc_max* (int) : Maximum message retry attempts

--- a/src/config.c
+++ b/src/config.c
@@ -1,0 +1,484 @@
+/****************************************************************************
+**
+** SPDX-License-Identifier: BSD-2-Clause-Patent
+**
+** SPDX-FileCopyrightText: Copyright (c) 2024 SoftAtHome
+**
+** Redistribution and use in source and binary forms, with or
+** without modification, are permitted provided that the following
+** conditions are met:
+**
+** 1. Redistributions of source code must retain the above copyright
+** notice, this list of conditions and the following disclaimer.
+**
+** 2. Redistributions in binary form must reproduce the above
+** copyright notice, this list of conditions and the following
+** disclaimer in the documentation and/or other materials provided
+** with the distribution.
+**
+** Subject to the terms and conditions of this license, each
+** copyright holder and contributor hereby grants to those receiving
+** rights under this license a perpetual, worldwide, non-exclusive,
+** no-charge, royalty-free, irrevocable (except for failure to
+** satisfy the conditions of this license) patent license to make,
+** have made, use, offer to sell, sell, import, and otherwise
+** transfer this software, where such license applies only to those
+** patent claims, already acquired or hereafter acquired, licensable
+** by such copyright holder or contributor that are necessarily
+** infringed by:
+**
+** (a) their Contribution(s) (the licensed copyrights of copyright
+** holders and non-copyrightable additions of contributors, in
+** source or binary form) alone; or
+**
+** (b) combination of their Contribution(s) with the work of
+** authorship to which such Contribution(s) was added by such
+** copyright holder or contributor, if, at the time the Contribution
+** is added, such addition causes such combination to be necessarily
+** infringed. The patent license shall not apply to any other
+** combinations which include the Contribution.
+**
+** Except as expressly stated above, no rights or licenses from any
+** copyright holder or contributor is granted under this license,
+** whether expressly, by implication, estoppel or otherwise.
+**
+** DISCLAIMER
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+** CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+** MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+** CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+** USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+** AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+** LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+** ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+** POSSIBILITY OF SUCH DAMAGE.
+**
+****************************************************************************/
+#include "odhcp6c.h"
+
+#include <string.h>
+#include <resolv.h>
+#include <limits.h>
+#include <arpa/inet.h>
+#include <stdlib.h>
+#include <syslog.h>
+
+#include "config.h"
+
+#define ARRAY_SEP " ,\t"
+
+static struct config_dhcp config_dhcp;
+
+struct config_dhcp *config_dhcp_get(void) {
+	return &config_dhcp;
+}
+
+void config_dhcp_reset(void) {
+	config_dhcp.release = true;
+	config_dhcp.dscp = 0;
+	config_dhcp.sol_timeout = DHCPV6_SOL_MAX_RT;
+	config_dhcp.sk_prio = 0;
+	config_dhcp.stateful_only_mode = false;
+	config_dhcp.ia_na_mode = IA_MODE_TRY;
+	config_dhcp.ia_pd_mode = IA_MODE_NONE;
+	config_dhcp.client_options = DHCPV6_CLIENT_FQDN | DHCPV6_ACCEPT_RECONFIGURE;
+	config_dhcp.allow_slaac_only = -1;
+	config_dhcp.oro_user_cnt = 0;
+}
+
+void config_set_release(bool enable) {
+	config_dhcp.release = enable;
+}
+
+bool config_set_dscp(unsigned int value) {
+	if(value > 63)
+		return false;
+	config_dhcp.dscp = value;
+	return true;
+}
+
+bool config_set_solicit_timeout(unsigned int timeout) {
+	if(timeout > INT32_MAX)
+		return false;
+
+	config_dhcp.sol_timeout = timeout;
+	return true;
+}
+
+bool config_set_sk_priority(unsigned int priority) {
+	if(priority > 6)
+		return false;
+
+	config_dhcp.sk_prio = priority;
+	return true;
+}
+
+void config_set_client_options(enum dhcpv6_config option, bool enable) {
+	if(enable) {
+		config_dhcp.client_options |= option;
+	} else {
+		config_dhcp.client_options &= ~option;
+	}
+}
+
+bool config_set_request_addresses(char* mode) {
+	if (!strcmp(mode, "force")) {
+		config_dhcp.ia_na_mode = IA_MODE_FORCE;
+		config_dhcp.allow_slaac_only = -1;
+	} else if (!strcmp(mode, "none"))
+		config_dhcp.ia_na_mode = IA_MODE_NONE;
+	else if (!strcmp(mode, "try"))
+		config_dhcp.ia_na_mode = IA_MODE_TRY;
+	else
+		return false;
+
+	return true;
+}
+
+bool config_set_request_prefix(unsigned int length, unsigned int id) {
+	struct odhcp6c_request_prefix prefix = {0};
+
+	odhcp6c_clear_state(STATE_IA_PD_INIT);
+
+	if (config_dhcp.ia_pd_mode != IA_MODE_FORCE)
+		config_dhcp.ia_pd_mode = length > 128 ? IA_MODE_NONE : IA_MODE_TRY;
+
+	if(length <= 128) {
+		if (config_dhcp.allow_slaac_only >= 0 && config_dhcp.allow_slaac_only < 10)
+			config_dhcp.allow_slaac_only = 10;
+
+		prefix.length = length;
+		prefix.iaid = htonl(id);
+
+		if (odhcp6c_add_state(STATE_IA_PD_INIT, &prefix, sizeof(prefix))) {
+			syslog(LOG_ERR, "Failed to set request IPv6-Prefix");
+			return false;
+		}
+	}
+
+	return true;
+}
+
+void config_set_force_prefix(bool enable) {
+	if(enable) {
+		config_dhcp.allow_slaac_only = -1;
+		config_dhcp.ia_pd_mode = IA_MODE_FORCE;
+	}
+	else {
+		config_dhcp.ia_pd_mode = IA_MODE_NONE;
+	}
+}
+
+void config_set_stateful_only(bool enable) {
+	config_dhcp.stateful_only_mode = enable;
+}
+
+void config_set_allow_slaac_only(int value) {
+	config_dhcp.allow_slaac_only = value;
+}
+
+void config_clear_requested_options(void) {
+	config_dhcp.oro_user_cnt = 0;
+}
+
+bool config_add_requested_options(unsigned int option) {
+	if(option > UINT16_MAX)
+		return false;
+
+	option = htons(option);
+	if (odhcp6c_insert_state(STATE_ORO, 0, &option, 2)) {
+		return false;
+	}
+	config_dhcp.oro_user_cnt++;
+	return true;
+}
+
+void config_clear_send_options(void) {
+	odhcp6c_clear_state(STATE_OPTS);
+}
+
+bool config_add_send_options(char* option) {
+	return (config_parse_opt(option) == 0);
+}
+
+static int config_parse_opt_u8(const char *src, uint8_t **dst)
+{
+	int len = strlen(src);
+
+	*dst = realloc(*dst, len/2);
+	if (!*dst)
+		return -1;
+
+	return script_unhexlify(*dst, len, src);
+}
+
+static int config_parse_opt_string(const char *src, uint8_t **dst, const bool array)
+{
+	int o_len = 0;
+	char *sep = strpbrk(src, ARRAY_SEP);
+
+	if (sep && !array)
+		return -1;
+
+	do {
+		if (sep) {
+			*sep = 0;
+			sep++;
+		}
+
+		int len = strlen(src);
+
+		*dst = realloc(*dst, o_len + len);
+		if (!*dst)
+			return -1;
+
+		memcpy(&((*dst)[o_len]), src, len);
+
+		o_len += len;
+		src = sep;
+
+		if (sep)
+			sep = strpbrk(src, ARRAY_SEP);
+	} while (src);
+
+	return o_len;
+}
+
+static int config_parse_opt_dns_string(const char *src, uint8_t **dst, const bool array)
+{
+	int o_len = 0;
+	char *sep = strpbrk(src, ARRAY_SEP);
+
+	if (sep && !array)
+		return -1;
+
+	do {
+		uint8_t tmp[256];
+
+		if (sep) {
+			*sep = 0;
+			sep++;
+		}
+
+		int len = dn_comp(src, tmp, sizeof(tmp), NULL, NULL);
+		if (len < 0)
+			return -1;
+
+		*dst = realloc(*dst, o_len + len);
+		if (!*dst)
+			return -1;
+
+		memcpy(&((*dst)[o_len]), tmp, len);
+
+		o_len += len;
+		src = sep;
+
+		if (sep)
+			sep = strpbrk(src, ARRAY_SEP);
+	} while (src);
+
+	return o_len;
+}
+
+static int config_parse_opt_ip6(const char *src, uint8_t **dst, const bool array)
+{
+	int o_len = 0;
+	char *sep = strpbrk(src, ARRAY_SEP);
+
+	if (sep && !array)
+		return -1;
+
+	do {
+		int len = sizeof(struct in6_addr);
+
+		if (sep) {
+			*sep = 0;
+			sep++;
+		}
+
+		*dst = realloc(*dst, o_len + len);
+		if (!*dst)
+			return -1;
+
+		if (inet_pton(AF_INET6, src, &((*dst)[o_len])) < 1)
+			return -1;
+
+		o_len += len;
+		src = sep;
+
+		if (sep)
+			sep = strpbrk(src, ARRAY_SEP);
+	} while (src);
+
+	return o_len;
+}
+
+static int config_parse_opt_user_class(const char *src, uint8_t **dst, const bool array)
+{
+	int o_len = 0;
+	char *sep = strpbrk(src, ARRAY_SEP);
+
+	if (sep && !array)
+		return -1;
+
+	do {
+		if (sep) {
+			*sep = 0;
+			sep++;
+		}
+		uint16_t str_len = strlen(src);
+
+		*dst = realloc(*dst, o_len + str_len + 2);
+		if (!*dst)
+			return -1;
+
+		struct user_class {
+			uint16_t len;
+			uint8_t data[];
+		} *e = (struct user_class *)&((*dst)[o_len]);
+
+		e->len = ntohs(str_len);
+		memcpy(e->data, src, str_len);
+
+		o_len += str_len + 2;
+		src = sep;
+
+		if (sep)
+			sep = strpbrk(src, ARRAY_SEP);
+	} while (src);
+
+	return o_len;
+}
+
+static uint8_t *config_state_find_opt(const uint16_t code)
+{
+	size_t opts_len;
+	uint8_t *odata, *opts = odhcp6c_get_state(STATE_OPTS, &opts_len);
+	uint16_t otype, olen;
+
+	dhcpv6_for_each_option(opts, &opts[opts_len], otype, olen, odata) {
+		if (otype == code)
+			return &odata[-4];
+	}
+
+	return NULL;
+}
+
+int config_add_opt(const uint16_t code, const uint8_t *data, const uint16_t len)
+{
+	struct {
+		uint16_t code;
+		uint16_t len;
+	} opt_hdr = { htons(code), htons(len) };
+
+	if (config_state_find_opt(code))
+		return -1;
+
+	if (odhcp6c_add_state(STATE_OPTS, &opt_hdr, sizeof(opt_hdr)) ||
+			odhcp6c_add_state(STATE_OPTS, data, len)) {
+		syslog(LOG_ERR, "Failed to add option %hu", code);
+		return 1;
+	}
+
+	return 0;
+}
+
+int config_parse_opt_data(const char *data, uint8_t **dst, const unsigned int type,
+		const bool array)
+{
+	int ret = 0;
+
+	switch (type) {
+	case OPT_U8:
+		ret = config_parse_opt_u8(data, dst);
+		break;
+
+	case OPT_STR:
+		ret = config_parse_opt_string(data, dst, array);
+		break;
+
+	case OPT_DNS_STR:
+		ret = config_parse_opt_dns_string(data, dst, array);
+		break;
+
+	case OPT_IP6:
+		ret = config_parse_opt_ip6(data, dst, array);
+		break;
+
+	case OPT_USER_CLASS:
+		ret = config_parse_opt_user_class(data, dst, array);
+		break;
+
+	default:
+		ret = -1;
+		break;
+	}
+
+	return ret;
+}
+
+int config_parse_opt(const char *opt)
+{
+	uint32_t optn;
+	char *data;
+	uint8_t *payload = NULL;
+	int payload_len;
+	unsigned int type = OPT_U8;
+	bool array = false;
+	struct odhcp6c_opt *dopt = NULL;
+	int ret = -1;
+
+	data = strpbrk(opt, ":");
+	if (!data)
+		return -1;
+
+	*data = '\0';
+	data++;
+
+	if (strlen(opt) == 0 || strlen(data) == 0)
+		return -1;
+
+	dopt = odhcp6c_find_opt_by_name(opt);
+	if (!dopt) {
+		char *e;
+		optn = strtoul(opt, &e, 0);
+		if (*e || e == opt || optn > USHRT_MAX)
+			return -1;
+
+		dopt = odhcp6c_find_opt(optn);
+	} else
+		optn = dopt->code;
+
+	/* Check if the type for the content is well-known */
+	if (dopt) {
+		/* Refuse internal options */
+		if (dopt->flags & OPT_INTERNAL)
+			return -1;
+
+		type = dopt->flags & OPT_MASK_SIZE;
+		array = ((dopt->flags & OPT_ARRAY) == OPT_ARRAY) ? true : false;
+	} else if (data[0] == '"' || data[0] == '\'') {
+		char *end = strrchr(data + 1, data[0]);
+
+		if (end && (end == (data + strlen(data) - 1))) {
+			/* Raw option is specified as a string */
+			type = OPT_STR;
+			data++;
+			*end = '\0';
+		}
+
+	}
+
+	payload_len = config_parse_opt_data(data, &payload, type, array);
+	if (payload_len > 0)
+		ret = config_add_opt(optn, payload, payload_len);
+
+	free(payload);
+
+	return ret;
+}

--- a/src/config.c
+++ b/src/config.c
@@ -109,6 +109,9 @@ void config_dhcp_reset(void) {
 	config_dhcp.irt_default = DHCPV6_IRT_DEFAULT;
 	config_dhcp.irt_min = DHCPV6_IRT_MIN;
 	config_dhcp.rand_factor = DHCPV6_RAND_FACTOR;
+	config_dhcp.auth_protocol = AUTH_PROT_RKAP;
+	free(config_dhcp.auth_token);
+	config_dhcp.auth_token = NULL;
 }
 
 void config_set_release(bool enable) {
@@ -294,6 +297,30 @@ bool config_set_rand_factor(unsigned int value)
 	}
 	config_dhcp.rand_factor = value;
 	return true;
+}
+
+bool config_set_auth_protocol(const char* protocol)
+{
+	if (!strcmp(protocol, "None")) {
+		config_dhcp.auth_protocol = AUTH_PROT_NONE;
+	} else if (!strcmp(protocol, "ConfigurationToken"))
+		config_dhcp.auth_protocol = AUTH_PROT_TOKEN;
+	else if (!strcmp(protocol, "ReconfigureKeyAuthentication"))
+		config_dhcp.auth_protocol = AUTH_PROT_RKAP;
+	else {
+		syslog(LOG_ERR, "Invalid Authentification protocol");
+		return false;
+	}
+
+	return true;
+}
+
+bool config_set_auth_token(const char* token)
+{
+	free(config_dhcp.auth_token);
+
+	config_dhcp.auth_token = strdup(token);
+	return config_dhcp.auth_token != NULL; 
 }
 
 static int config_parse_opt_u8(const char *src, uint8_t **dst)

--- a/src/config.h
+++ b/src/config.h
@@ -95,6 +95,8 @@ struct config_dhcp {
 	uint32_t irt_default;
 	uint32_t irt_min;
 	uint16_t rand_factor;
+	enum odhcp6c_auth_protocol auth_protocol;
+	char* auth_token;
 };
 
 struct config_dhcp *config_dhcp_get(void);
@@ -119,6 +121,8 @@ bool config_set_rtx_rc_max(enum config_dhcp_msg msg, unsigned int value);
 bool config_set_irt_default(unsigned int value);
 bool config_set_irt_min(unsigned int value);
 bool config_set_rand_factor(unsigned int value);
+bool config_set_auth_protocol(const char* protocol);
+bool config_set_auth_token(const char* token);
 
 int config_add_opt(const uint16_t code, const uint8_t *data, const uint16_t len);
 int config_parse_opt_data(const char *data, uint8_t **dst, const unsigned int type, const bool array);

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,100 @@
+/****************************************************************************
+**
+** SPDX-License-Identifier: BSD-2-Clause-Patent
+**
+** SPDX-FileCopyrightText: Copyright (c) 2024 SoftAtHome
+**
+** Redistribution and use in source and binary forms, with or
+** without modification, are permitted provided that the following
+** conditions are met:
+**
+** 1. Redistributions of source code must retain the above copyright
+** notice, this list of conditions and the following disclaimer.
+**
+** 2. Redistributions in binary form must reproduce the above
+** copyright notice, this list of conditions and the following
+** disclaimer in the documentation and/or other materials provided
+** with the distribution.
+**
+** Subject to the terms and conditions of this license, each
+** copyright holder and contributor hereby grants to those receiving
+** rights under this license a perpetual, worldwide, non-exclusive,
+** no-charge, royalty-free, irrevocable (except for failure to
+** satisfy the conditions of this license) patent license to make,
+** have made, use, offer to sell, sell, import, and otherwise
+** transfer this software, where such license applies only to those
+** patent claims, already acquired or hereafter acquired, licensable
+** by such copyright holder or contributor that are necessarily
+** infringed by:
+**
+** (a) their Contribution(s) (the licensed copyrights of copyright
+** holders and non-copyrightable additions of contributors, in
+** source or binary form) alone; or
+**
+** (b) combination of their Contribution(s) with the work of
+** authorship to which such Contribution(s) was added by such
+** copyright holder or contributor, if, at the time the Contribution
+** is added, such addition causes such combination to be necessarily
+** infringed. The patent license shall not apply to any other
+** combinations which include the Contribution.
+**
+** Except as expressly stated above, no rights or licenses from any
+** copyright holder or contributor is granted under this license,
+** whether expressly, by implication, estoppel or otherwise.
+**
+** DISCLAIMER
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+** CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+** MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+** CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+** USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+** AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+** LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+** ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+** POSSIBILITY OF SUCH DAMAGE.
+**
+****************************************************************************/
+
+#ifndef _CONFIG_H__
+#define _CONFIG_H__
+
+struct config_dhcp {
+	bool release;
+	int dscp;
+	int sol_timeout;
+	int sk_prio;
+	bool stateful_only_mode;
+	enum odhcp6c_ia_mode ia_na_mode;
+	enum odhcp6c_ia_mode ia_pd_mode;
+	unsigned int client_options;
+	int allow_slaac_only;
+	unsigned int oro_user_cnt;
+};
+
+struct config_dhcp *config_dhcp_get(void);
+void config_dhcp_reset(void);
+void config_set_release(bool enable);
+bool config_set_dscp(unsigned int value) ;
+bool config_set_solicit_timeout(unsigned int timeout);
+bool config_set_sk_priority(unsigned int priority);
+void config_set_client_options(enum dhcpv6_config option, bool enable);
+bool config_set_request_addresses(char *mode);
+bool config_set_request_prefix(unsigned int length, unsigned int id);
+void config_set_force_prefix(bool enable);
+void config_set_stateful_only(bool enable);
+void config_set_allow_slaac_only(int value);
+void config_clear_requested_options(void) ;
+bool config_add_requested_options(unsigned int option);
+void config_clear_send_options(void);
+bool config_add_send_options(char *option);
+
+int config_add_opt(const uint16_t code, const uint8_t *data, const uint16_t len);
+int config_parse_opt_data(const char *data, uint8_t **dst, const unsigned int type, const bool array);
+int config_parse_opt(const char *opt);
+
+#endif

--- a/src/config.h
+++ b/src/config.h
@@ -63,10 +63,27 @@
 #ifndef _CONFIG_H__
 #define _CONFIG_H__
 
+struct config_dhcp_rtx {
+	uint8_t delay_max;
+	uint8_t timeout_init;
+	uint16_t timeout_max;
+	uint8_t rc_max;
+};
+
+enum config_dhcp_msg {
+	CONFIG_DHCP_SOLICIT,
+	CONFIG_DHCP_REQUEST,
+	CONFIG_DHCP_RENEW,
+	CONFIG_DHCP_REBIND,
+	CONFIG_DHCP_RELEASE,
+	CONFIG_DHCP_DECLINE,
+	CONFIG_DHCP_INFO_REQ,
+	CONFIG_DHCP_MAX
+};
+
 struct config_dhcp {
 	bool release;
 	int dscp;
-	int sol_timeout;
 	int sk_prio;
 	bool stateful_only_mode;
 	enum odhcp6c_ia_mode ia_na_mode;
@@ -74,13 +91,16 @@ struct config_dhcp {
 	unsigned int client_options;
 	int allow_slaac_only;
 	unsigned int oro_user_cnt;
+	struct config_dhcp_rtx message_rtx[CONFIG_DHCP_MAX];
+	uint32_t irt_default;
+	uint32_t irt_min;
+	uint16_t rand_factor;
 };
 
 struct config_dhcp *config_dhcp_get(void);
 void config_dhcp_reset(void);
 void config_set_release(bool enable);
 bool config_set_dscp(unsigned int value) ;
-bool config_set_solicit_timeout(unsigned int timeout);
 bool config_set_sk_priority(unsigned int priority);
 void config_set_client_options(enum dhcpv6_config option, bool enable);
 bool config_set_request_addresses(char *mode);
@@ -92,9 +112,18 @@ void config_clear_requested_options(void) ;
 bool config_add_requested_options(unsigned int option);
 void config_clear_send_options(void);
 bool config_add_send_options(char *option);
+bool config_set_rtx_delay_max(enum config_dhcp_msg msg, unsigned int value);
+bool config_set_rtx_timeout_init(enum config_dhcp_msg msg, unsigned int value);
+bool config_set_rtx_timeout_max(enum config_dhcp_msg msg, unsigned int value);
+bool config_set_rtx_rc_max(enum config_dhcp_msg msg, unsigned int value);
+bool config_set_irt_default(unsigned int value);
+bool config_set_irt_min(unsigned int value);
+bool config_set_rand_factor(unsigned int value);
 
 int config_add_opt(const uint16_t code, const uint8_t *data, const uint16_t len);
 int config_parse_opt_data(const char *data, uint8_t **dst, const unsigned int type, const bool array);
 int config_parse_opt(const char *opt);
+
+void config_apply_dhcp_rtx(struct dhcpv6_retx* dhcpv6_retx);
 
 #endif

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -210,6 +210,83 @@ static char *dhcpv6_status_code_to_str(uint16_t code)
 	return "Unknown";
 }
 
+const char *dhcpv6_state_to_str(enum dhcpv6_state state)
+{
+	switch (state) {
+	case DHCPV6_INIT:
+		return "INIT";
+
+	case DHCPV6_SOLICIT:
+		return "SOLICIT";
+
+	case DHCPV6_SOLICIT_PROCESSING:
+		return "SOLICIT_PROCESSING";
+
+	case DHCPV6_ADVERT:
+		return "ADVERT";
+
+	case DHCPV6_REQUEST:
+		return "REQUEST";
+
+	case DHCPV6_REQUEST_PROCESSING:
+		return "REQUEST_PROCESSING";
+
+	case DHCPV6_REPLY:
+		return "REPLY";
+
+	case DHCPV6_BOUND:
+		return "BOUND";
+
+	case DHCPV6_BOUND_PROCESSING:
+		return "BOUND_PROCESSING";
+
+	case DHCPV6_BOUND_REPLY:
+		return "BOUND_REPLY";
+
+	case DHCPV6_RECONF:
+		return "RECONF";
+
+	case DHCPV6_RECONF_PROCESSING:
+		return "RECONF_PROCESSING";
+
+	case DHCPV6_RECONF_REPLY:
+		return "RECONF_REPLY";
+
+	case DHCPV6_RENEW:
+		return "RENEW";
+
+	case DHCPV6_RENEW_PROCESSING:
+		return "RENEW_PROCESSING";
+
+	case DHCPV6_RENEW_REPLY:
+		return "RENEW_REPLY";
+
+	case DHCPV6_REBIND:
+		return "REBIND";
+
+	case DHCPV6_REBIND_PROCESSING:
+		return "REBIND_PROCESSING";
+
+	case DHCPV6_REBIND_REPLY:
+		return "REBIND_REPLY";
+
+	case DHCPV6_INFO:
+		return "INFO";
+
+	case DHCPV6_INFO_PROCESSING:
+		return "INFO_PROCESSING";
+
+	case DHCPV6_INFO_REPLY:
+		return "INFO_REPLY";
+
+	case DHCPV6_EXIT:
+		return "EXIT";
+		
+	default:
+		return "INVALID_STATE";
+	}
+}
+
 static int fd_set_nonblocking(int sockfd)
 {
     int flags = fcntl(sockfd, F_GETFL, 0);

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -80,7 +80,7 @@ static reply_handler dhcpv6_handle_reconfigure;
 static int dhcpv6_commit_advert(void);
 
 // RFC 3315 - 5.5 Timeout and Delay values
-static struct dhcpv6_retx dhcpv6_retx[_DHCPV6_MSG_MAX] = {
+static const struct dhcpv6_retx dhcpv6_retx_default[_DHCPV6_MSG_MAX] = {
 	[DHCPV6_MSG_UNKNOWN] = {false, 1, 120, 0, "<POLL>",
 			dhcpv6_handle_reconfigure, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1, 0},
 	[DHCPV6_MSG_SOLICIT] = {true, 1, DHCPV6_SOL_MAX_RT, 0, "SOLICIT",
@@ -96,6 +96,7 @@ static struct dhcpv6_retx dhcpv6_retx[_DHCPV6_MSG_MAX] = {
 	[DHCPV6_MSG_INFO_REQ] = {true, 1, DHCPV6_INF_MAX_RT, 0, "INFOREQ",
 			dhcpv6_handle_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1, 0},
 };
+static struct dhcpv6_retx dhcpv6_retx[_DHCPV6_MSG_MAX] = {0};
 
 // Sockets
 static int sock = -1;
@@ -400,6 +401,7 @@ void dhcpv6_reset_stats(void)
 
 int init_dhcpv6(const char *ifname, unsigned int options, int sk_prio, int sol_timeout, unsigned int dscp)
 {
+	memcpy(dhcpv6_retx, dhcpv6_retx_default, sizeof(dhcpv6_retx));
 	client_options = options;
 	dhcpv6_retx[DHCPV6_MSG_SOLICIT].max_timeo = sol_timeout;
 

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -410,6 +410,9 @@ int init_dhcpv6(const char *ifname)
 	config_apply_dhcp_rtx(dhcpv6_retx);
 
 	client_options = config_dhcp->client_options;
+	na_mode = config_dhcp->ia_na_mode;
+	pd_mode = config_dhcp->ia_pd_mode;
+	stateful_only_mode = config_dhcp->stateful_only_mode;
 
 	sock = socket(AF_INET6, SOCK_DGRAM | SOCK_CLOEXEC, IPPROTO_UDP);
 	if (sock < 0)
@@ -538,13 +541,9 @@ enum {
 	IOV_TOTAL
 };
 
-int dhcpv6_set_ia_mode(enum odhcp6c_ia_mode na, enum odhcp6c_ia_mode pd, bool stateful_only)
+int dhcpv6_get_ia_mode(void)
 {
 	int mode = DHCPV6_UNKNOWN;
-
-	na_mode = na;
-	pd_mode = pd;
-	stateful_only_mode = stateful_only;
 
 	if (na_mode == IA_MODE_NONE && pd_mode == IA_MODE_NONE)
 		mode = DHCPV6_STATELESS;
@@ -1722,8 +1721,6 @@ int dhcpv6_promote_server_cand(void)
 
 		dhcpv6_retx[DHCPV6_MSG_SOLICIT].max_timeo = cand->sol_max_rt;
 		dhcpv6_retx[DHCPV6_MSG_INFO_REQ].max_timeo = cand->inf_max_rt;
-
-		dhcpv6_set_state(DHCPV6_SOLICIT);
 		return -1;
 	}
 

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -1179,7 +1179,7 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 			if (!t1 && state_IAs != updated_IAs) {
 				if (updated_IAs)
 					// Publish updates
-					script_call("updated", 0, false);
+					notify_state_change("updated", 0, false);
 
 				/*
 				 * RFC8415 states following in §18.2.10.1 :
@@ -1203,7 +1203,7 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 			if (!t1 && !t2 && state_IAs != updated_IAs) {
 				if (updated_IAs)
 					// Publish updates
-					script_call("updated", 0, false);
+					notify_state_change("updated", 0, false);
 
 				/*
 				 * RFC8415 states following in §18.2.10.1 :

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -1661,7 +1661,7 @@ int dhcpv6_promote_server_cand(void)
 	if (!cand_len)
 		return -1;
 
-	if (cand->has_noaddravail && na_mode == IA_MODE_TRY) {
+	if (!cand->ia_pd_len && cand->has_noaddravail && na_mode == IA_MODE_TRY) {
 		na_mode = IA_MODE_NONE;
 
 		dhcpv6_retx[DHCPV6_MSG_SOLICIT].max_timeo = cand->sol_max_rt;

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -82,19 +82,19 @@ static int dhcpv6_commit_advert(void);
 // RFC 3315 - 5.5 Timeout and Delay values
 static struct dhcpv6_retx dhcpv6_retx[_DHCPV6_MSG_MAX] = {
 	[DHCPV6_MSG_UNKNOWN] = {false, 1, 120, 0, "<POLL>",
-			dhcpv6_handle_reconfigure, NULL},
+			dhcpv6_handle_reconfigure, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
 	[DHCPV6_MSG_SOLICIT] = {true, 1, DHCPV6_SOL_MAX_RT, 0, "SOLICIT",
-			dhcpv6_handle_advert, dhcpv6_commit_advert},
+			dhcpv6_handle_advert, dhcpv6_commit_advert, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
 	[DHCPV6_MSG_REQUEST] = {true, 1, DHCPV6_REQ_MAX_RT, 10, "REQUEST",
-			dhcpv6_handle_reply, NULL},
+			dhcpv6_handle_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
 	[DHCPV6_MSG_RENEW] = {false, 10, DHCPV6_REN_MAX_RT, 0, "RENEW",
-			dhcpv6_handle_reply, NULL},
+			dhcpv6_handle_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
 	[DHCPV6_MSG_REBIND] = {false, 10, DHCPV6_REB_MAX_RT, 0, "REBIND",
-			dhcpv6_handle_rebind_reply, NULL},
-	[DHCPV6_MSG_RELEASE] = {false, 1, 0, 5, "RELEASE", NULL, NULL},
-	[DHCPV6_MSG_DECLINE] = {false, 1, 0, 5, "DECLINE", NULL, NULL},
+			dhcpv6_handle_rebind_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
+	[DHCPV6_MSG_RELEASE] = {false, 1, 0, 5, "RELEASE", NULL, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
+	[DHCPV6_MSG_DECLINE] = {false, 1, 0, 5, "DECLINE", NULL, NULL, false, 0, 0, 0,{0, 0, 0}, 0, 0, 0, -1},
 	[DHCPV6_MSG_INFO_REQ] = {true, 1, DHCPV6_INF_MAX_RT, 0, "INFOREQ",
-			dhcpv6_handle_reply, NULL},
+			dhcpv6_handle_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
 };
 
 // Sockets
@@ -1701,4 +1701,146 @@ int dhcpv6_promote_server_cand(void)
 	odhcp6c_remove_state(STATE_SERVER_CAND, 0, sizeof(*cand));
 
 	return ret;
+}
+
+int dhcpv6_send_request(enum dhcpv6_msg type)
+{
+	struct dhcpv6_retx *retx = &dhcpv6_retx[type];
+
+	if (!retx->is_retransmit){
+		retx->is_retransmit = true;
+		retx->rc = 0;
+		retx->timeout = UINT32_MAX;
+
+		if (retx->delay) {
+			struct timespec ts = {0, 0};
+			ts.tv_nsec = (dhcpv6_rand_delay((10000 * DHCPV6_REQ_DELAY) / 2) + (1000 * DHCPV6_REQ_DELAY) / 2) * 1000000;
+			while (nanosleep(&ts, &ts) < 0 && errno == EINTR);
+		}
+
+		if (type == DHCPV6_MSG_UNKNOWN)
+			retx->timeout = t1;
+		else if (type == DHCPV6_MSG_RENEW)
+			retx->timeout = (t2 > t1) ? t2 - t1 : ((t1 == UINT32_MAX) ? UINT32_MAX : 0);
+		else if (type == DHCPV6_MSG_REBIND)
+			retx->timeout = (t3 > t2) ? t3 - t2 : ((t2 == UINT32_MAX) ? UINT32_MAX : 0);
+
+		if (retx->timeout == 0)
+			return -1;
+
+		syslog(LOG_NOTICE, "Starting %s transaction (timeout %"PRIu64"s, max rc %d)",
+			retx->name, retx->timeout, retx->max_rc);
+
+		// Generate transaction ID
+		if (type != DHCPV6_MSG_UNKNOWN) {
+			odhcp6c_random(retx->tr_id, sizeof(retx->tr_id));
+		}
+
+		retx->start = odhcp6c_get_milli_time();
+		retx->round_start = retx->start;
+		retx->rto = 0;
+	}
+
+	if (retx->rto == 0) {
+		int64_t delay = dhcpv6_rand_delay(retx->init_timeo * 1000);
+
+		// First RT MUST be strictly greater than IRT for solicit messages (RFC3313 17.1.2)
+		while (type == DHCPV6_MSG_SOLICIT && delay <= 0)
+			delay = dhcpv6_rand_delay(retx->init_timeo * 1000);
+
+		retx->rto = (retx->init_timeo * 1000 + delay);
+	} else
+		retx->rto = (2 * retx->rto + dhcpv6_rand_delay(retx->rto));
+
+	if (retx->max_timeo && (retx->rto >= retx->max_timeo * 1000)) {
+		retx->rto = retx->max_timeo * 1000 +
+			dhcpv6_rand_delay(retx->max_timeo * 1000);
+        }
+
+	// Calculate end for this round and elapsed time
+	retx->round_end = retx->round_start + retx->rto;
+	uint64_t elapsed = retx->round_start - retx->start;
+
+	// Don't wait too long if timeout differs from infinite
+	if ((retx->timeout != UINT32_MAX) && (retx->round_end - retx->start > retx->timeout * 1000))
+		retx->round_end = retx->timeout * 1000 + retx->start;
+
+	// Built and send package
+	switch (type) {
+	case DHCPV6_MSG_UNKNOWN:
+		break;
+	default:
+		syslog(LOG_NOTICE, "Send %s message (elapsed %"PRIu64"ms, rc %d)",
+				retx->name, elapsed, retx->rc);
+	// Fall through
+	case DHCPV6_MSG_SOLICIT:
+	case DHCPV6_MSG_INFO_REQ:
+		dhcpv6_send(type, retx->tr_id, elapsed / 10);
+		retx->rc++;
+	}
+	return 0;
+}
+
+int dhcpv6_receive_response(enum dhcpv6_msg type)
+{
+	ssize_t len = -1;
+	struct dhcpv6_retx *retx = &dhcpv6_retx[type];
+
+	uint8_t buf[1536];
+	union {
+		struct cmsghdr hdr;
+		uint8_t buf[CMSG_SPACE(sizeof(struct in6_pktinfo))];
+	} cmsg_buf;
+
+	struct iovec iov = {buf, sizeof(buf)};
+	struct sockaddr_in6 addr;
+	struct msghdr msg = {.msg_name = &addr, .msg_namelen = sizeof(addr),
+			.msg_iov = &iov, .msg_iovlen = 1, .msg_control = cmsg_buf.buf,
+			.msg_controllen = sizeof(cmsg_buf)};
+	struct in6_pktinfo *pktinfo = NULL;
+	const struct dhcpv6_header *hdr = (const struct dhcpv6_header *)buf;
+
+	// Receive cycle
+	len = recvmsg(sock, &msg, 0);
+	if (len < 0) {
+		syslog(LOG_ERR, "Error occured when reading the response of (%s) error(%s)",
+			retx->name, strerror(errno));
+		return -1;
+	}
+
+	for (struct cmsghdr *ch = CMSG_FIRSTHDR(&msg); ch != NULL;
+		ch = CMSG_NXTHDR(&msg, ch)) {
+		if (ch->cmsg_level == SOL_IPV6 &&
+			ch->cmsg_type == IPV6_PKTINFO) {
+			pktinfo = (struct in6_pktinfo *)CMSG_DATA(ch);
+			break;
+		}
+	}
+
+	if (pktinfo == NULL) {
+        	return -1;
+	}
+
+	if (!dhcpv6_response_is_valid(buf, len, retx->tr_id, type,
+					 &pktinfo->ipi6_addr)) {
+		return -1;
+	}
+
+	uint8_t *opt = &buf[4];
+	uint8_t *opt_end = opt + len - 4;
+	retx->round_start = odhcp6c_get_milli_time();
+	uint64_t elapsed = retx->round_start - retx->start;
+
+	syslog(LOG_NOTICE, "Got a valid %s after %"PRIu64"ms",
+			       dhcpv6_msg_to_str(hdr->msg_type), elapsed);
+
+    	if (retx->handler_reply) {
+        	retx->reply_ret = retx->handler_reply(type, retx->rc, opt, opt_end, &addr);
+		len = retx->reply_ret;
+	}
+
+	if (len > 0 && retx->round_end - retx->round_start > 1000)
+		retx->round_end = 1000 + retx->round_start;
+
+	return retx->reply_ret;
 }

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -1369,6 +1369,9 @@ static int dhcpv6_handle_reply(enum dhcpv6_msg orig, _unused const int rc,
 		if (!odhcp6c_is_bound())
 			dhcpv6_clear_all_server_cand();
 
+		odhcp6c_clear_state(STATE_SERVER_ADDR);
+		odhcp6c_add_state(STATE_SERVER_ADDR, &from->sin6_addr, 16);
+
 		t1 = refresh;
 		break;
 

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -82,19 +82,19 @@ static int dhcpv6_commit_advert(void);
 // RFC 3315 - 5.5 Timeout and Delay values
 static struct dhcpv6_retx dhcpv6_retx[_DHCPV6_MSG_MAX] = {
 	[DHCPV6_MSG_UNKNOWN] = {false, 1, 120, 0, "<POLL>",
-			dhcpv6_handle_reconfigure, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
+			dhcpv6_handle_reconfigure, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1, 0},
 	[DHCPV6_MSG_SOLICIT] = {true, 1, DHCPV6_SOL_MAX_RT, 0, "SOLICIT",
-			dhcpv6_handle_advert, dhcpv6_commit_advert, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
+			dhcpv6_handle_advert, dhcpv6_commit_advert, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1, 0},
 	[DHCPV6_MSG_REQUEST] = {true, 1, DHCPV6_REQ_MAX_RT, 10, "REQUEST",
-			dhcpv6_handle_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
+			dhcpv6_handle_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1, 0},
 	[DHCPV6_MSG_RENEW] = {false, 10, DHCPV6_REN_MAX_RT, 0, "RENEW",
-			dhcpv6_handle_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
+			dhcpv6_handle_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1, 0},
 	[DHCPV6_MSG_REBIND] = {false, 10, DHCPV6_REB_MAX_RT, 0, "REBIND",
-			dhcpv6_handle_rebind_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
-	[DHCPV6_MSG_RELEASE] = {false, 1, 0, 5, "RELEASE", NULL, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
-	[DHCPV6_MSG_DECLINE] = {false, 1, 0, 5, "DECLINE", NULL, NULL, false, 0, 0, 0,{0, 0, 0}, 0, 0, 0, -1},
+			dhcpv6_handle_rebind_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1, 0},
+	[DHCPV6_MSG_RELEASE] = {false, 1, 0, 5, "RELEASE", NULL, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1, 0},
+	[DHCPV6_MSG_DECLINE] = {false, 1, 0, 5, "DECLINE", NULL, NULL, false, 0, 0, 0,{0, 0, 0}, 0, 0, 0, -1, 0},
 	[DHCPV6_MSG_INFO_REQ] = {true, 1, DHCPV6_INF_MAX_RT, 0, "INFOREQ",
-			dhcpv6_handle_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1},
+			dhcpv6_handle_reply, NULL, false, 0, 0, 0, {0, 0, 0}, 0, 0, 0, -1, 0},
 };
 
 // Sockets
@@ -109,6 +109,10 @@ static bool accept_reconfig = false;
 // Server unicast address
 static struct in6_addr server_addr = IN6ADDR_ANY_INIT;
 
+// Initial state of the dhcpv6
+static enum dhcpv6_state dhcpv6_state = DHCPV6_INIT;
+static int dhcpv6_state_timeout = 0;
+
 // Reconfigure key
 static uint8_t reconf_key[16];
 
@@ -121,6 +125,18 @@ static uint32_t ntohl_unaligned(const uint8_t *data)
 
 	memcpy(&buf, data, sizeof(buf));
 	return ntohl(buf);
+}
+
+static void dhcpv6_next_state(void)
+{
+	dhcpv6_state++;
+	dhcpv6_reset_state_timeout();
+}
+
+static void dhcpv6_prev_state(void)
+{
+	dhcpv6_state--;
+	dhcpv6_reset_state_timeout();
 }
 
 static char *dhcpv6_msg_to_str(enum dhcpv6_msg msg)
@@ -209,6 +225,39 @@ static int fd_set_nonblocking(int sockfd)
     }
 
     return 0;
+}
+
+int dhcpv6_get_socket(void)
+{
+	return sock;
+}
+
+enum dhcpv6_state dhcpv6_get_state(void)
+{
+	return dhcpv6_state;
+}
+
+void dhcpv6_set_state(enum dhcpv6_state state)
+{
+	dhcpv6_state = state;
+	dhcpv6_reset_state_timeout();
+}
+
+int dhcpv6_get_state_timeout(void)
+{
+	return dhcpv6_state_timeout;
+}
+
+void dhcpv6_set_state_timeout(int timeout)
+{
+	if(timeout > 0 && (dhcpv6_state_timeout == 0 || timeout < dhcpv6_state_timeout)) {
+		dhcpv6_state_timeout = timeout;
+	}
+}
+
+void dhcpv6_reset_state_timeout(void)
+{
+	dhcpv6_state_timeout = 0;
 }
 
 int init_dhcpv6(const char *ifname, unsigned int options, int sk_prio, int sol_timeout, unsigned int dscp)
@@ -650,156 +699,6 @@ static int64_t dhcpv6_rand_delay(int64_t time)
 	return (time * ((int64_t)random % 1000LL)) / 10000LL;
 }
 
-int dhcpv6_request(enum dhcpv6_msg type)
-{
-	uint8_t rc = 0;
-	uint64_t timeout = UINT32_MAX;
-	struct dhcpv6_retx *retx = &dhcpv6_retx[type];
-
-	if (retx->delay) {
-		struct timespec ts = {0, 0};
-		ts.tv_nsec = (dhcpv6_rand_delay((10000 * DHCPV6_REQ_DELAY) / 2) + (1000 * DHCPV6_REQ_DELAY) / 2) * 1000000;
-
-		while (nanosleep(&ts, &ts) < 0 && errno == EINTR);
-	}
-
-	if (type == DHCPV6_MSG_UNKNOWN)
-		timeout = t1;
-	else if (type == DHCPV6_MSG_RENEW)
-		timeout = (t2 > t1) ? t2 - t1 : ((t1 == UINT32_MAX) ? UINT32_MAX : 0);
-	else if (type == DHCPV6_MSG_REBIND)
-		timeout = (t3 > t2) ? t3 - t2 : ((t2 == UINT32_MAX) ? UINT32_MAX : 0);
-
-	if (timeout == 0)
-		return -1;
-
-	syslog(LOG_NOTICE, "Starting %s transaction (timeout %"PRIu64"s, max rc %d)",
-			retx->name, timeout, retx->max_rc);
-
-	uint64_t start = odhcp6c_get_milli_time(), round_start = start, elapsed;
-
-	// Generate transaction ID
-	uint8_t trid[3] = {0, 0, 0};
-	if (type != DHCPV6_MSG_UNKNOWN)
-		odhcp6c_random(trid, sizeof(trid));
-
-	ssize_t len = -1;
-	int64_t rto = 0;
-
-	do {
-		if (rto == 0) {
-			int64_t delay = dhcpv6_rand_delay(retx->init_timeo * 1000);
-
-			// First RT MUST be strictly greater than IRT for solicit messages (RFC3313 17.1.2)
-			while (type == DHCPV6_MSG_SOLICIT && delay <= 0)
-				delay = dhcpv6_rand_delay(retx->init_timeo * 1000);
-
-			rto = (retx->init_timeo * 1000 + delay);
-		} else
-			rto = (2 * rto + dhcpv6_rand_delay(rto));
-
-		if (retx->max_timeo && (rto >= retx->max_timeo * 1000))
-			rto = retx->max_timeo * 1000 +
-				dhcpv6_rand_delay(retx->max_timeo * 1000);
-
-		// Calculate end for this round and elapsed time
-		uint64_t round_end = round_start + rto;
-		elapsed = round_start - start;
-
-		// Don't wait too long if timeout differs from infinite
-		if ((timeout != UINT32_MAX) && (round_end - start > timeout * 1000))
-			round_end = timeout * 1000 + start;
-
-		// Built and send package
-		switch (type) {
-		case DHCPV6_MSG_UNKNOWN:
-			break;
-		default:
-			syslog(LOG_NOTICE, "Send %s message (elapsed %"PRIu64"ms, rc %d)",
-					retx->name, elapsed, rc);
-			// Fall through
-		case DHCPV6_MSG_SOLICIT:
-		case DHCPV6_MSG_INFO_REQ:
-			dhcpv6_send(type, trid, elapsed / 10);
-			rc++;
-		}
-
-		// Receive rounds
-		for (; len < 0 && (round_start < round_end);
-				round_start = odhcp6c_get_milli_time()) {
-			uint8_t buf[1536];
-			union {
-				struct cmsghdr hdr;
-				uint8_t buf[CMSG_SPACE(sizeof(struct in6_pktinfo))];
-			} cmsg_buf;
-			struct iovec iov = {buf, sizeof(buf)};
-			struct sockaddr_in6 addr;
-			struct msghdr msg = {.msg_name = &addr, .msg_namelen = sizeof(addr),
-					.msg_iov = &iov, .msg_iovlen = 1, .msg_control = cmsg_buf.buf,
-					.msg_controllen = sizeof(cmsg_buf)};
-			struct in6_pktinfo *pktinfo = NULL;
-			const struct dhcpv6_header *hdr = (const struct dhcpv6_header *)buf;
-
-			// Check for pending signal
-			if (odhcp6c_signal_process())
-				return -1;
-
-			// Set timeout for receiving
-			uint64_t t = round_end - round_start;
-			struct timeval tv = {t / 1000, (t % 1000) * 1000};
-			if (setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO,
-					&tv, sizeof(tv)) < 0)
-				syslog(LOG_ERR, "setsockopt SO_RCVTIMEO failed (%s)",
-						strerror(errno));
-
-			// Receive cycle
-			len = recvmsg(sock, &msg, 0);
-			if (len < 0)
-				continue;
-
-			for (struct cmsghdr *ch = CMSG_FIRSTHDR(&msg); ch != NULL;
-				ch = CMSG_NXTHDR(&msg, ch)) {
-				if (ch->cmsg_level == SOL_IPV6 &&
-					ch->cmsg_type == IPV6_PKTINFO) {
-					pktinfo = (struct in6_pktinfo *)CMSG_DATA(ch);
-					break;
-				}
-			}
-
-			if (pktinfo == NULL) {
-				len = -1;
-				continue;
-			}
-
-			if (!dhcpv6_response_is_valid(buf, len, trid,
-							type, &pktinfo->ipi6_addr)) {
-				len = -1;
-				continue;
-			}
-
-			uint8_t *opt = &buf[4];
-			uint8_t *opt_end = opt + len - 4;
-
-			round_start = odhcp6c_get_milli_time();
-			elapsed = round_start - start;
-			syslog(LOG_NOTICE, "Got a valid %s after %"PRIu64"ms",
-			       dhcpv6_msg_to_str(hdr->msg_type), elapsed);
-
-			if (retx->handler_reply)
-				len = retx->handler_reply(type, rc, opt, opt_end, &addr);
-
-			if (len > 0 && round_end - round_start > 1000)
-				round_end = 1000 + round_start;
-		}
-
-		// Allow
-		if (retx->handler_finish)
-			len = retx->handler_finish();
-	} while (len < 0 && ((timeout == UINT32_MAX) || (elapsed / 1000 < timeout)) &&
-			(!retx->max_rc || rc < retx->max_rc));
-	return len;
-}
-
 // Message validation checks according to RFC3315 chapter 15
 static bool dhcpv6_response_is_valid(const void *buf, ssize_t len,
 		const uint8_t transaction[3], enum dhcpv6_msg type,
@@ -902,29 +801,6 @@ static bool dhcpv6_response_is_valid(const void *buf, ssize_t len,
 	}
 
 	return clientid_ok && serverid_ok;
-}
-
-int dhcpv6_poll_reconfigure(void)
-{
-	int ret = dhcpv6_request(DHCPV6_MSG_UNKNOWN);
-
-	switch (ret) {
-	/*
-	 * Only RENEW/REBIND/INFORMATION REQUEST
-	 * message transmission can be requested
-	 * by a RECONFIGURE
-	 */
-	case DHCPV6_MSG_RENEW:
-	case DHCPV6_MSG_REBIND:
-	case DHCPV6_MSG_INFO_REQ:
-		ret = dhcpv6_request(ret);
-		break;
-
-	default:
-		break;
-	}
-
-	return ret;
 }
 
 static int dhcpv6_handle_reconfigure(enum dhcpv6_msg orig, const int rc,
@@ -1615,8 +1491,10 @@ static void dhcpv6_handle_ia_status_code(const enum dhcpv6_msg orig,
 		switch (orig) {
 		case DHCPV6_MSG_RENEW:
 		case DHCPV6_MSG_REBIND:
-			if ((*ret > 0) && !handled_status_codes[code])
-				*ret = dhcpv6_request(DHCPV6_MSG_REQUEST);
+			if ((*ret > 0) && !handled_status_codes[code]) {
+				dhcpv6_set_state(DHCPV6_REQUEST);
+				*ret = -1;
+			}
 			break;
 
 		default:
@@ -1693,7 +1571,8 @@ int dhcpv6_promote_server_cand(void)
 		dhcpv6_retx[DHCPV6_MSG_SOLICIT].max_timeo = cand->sol_max_rt;
 		dhcpv6_retx[DHCPV6_MSG_INFO_REQ].max_timeo = cand->inf_max_rt;
 
-		return dhcpv6_request(DHCPV6_MSG_SOLICIT);
+		dhcpv6_set_state(DHCPV6_SOLICIT);
+		return -1;
 	}
 
 	hdr[0] = htons(DHCPV6_OPT_SERVERID);
@@ -1727,17 +1606,29 @@ int dhcpv6_promote_server_cand(void)
 int dhcpv6_send_request(enum dhcpv6_msg type)
 {
 	struct dhcpv6_retx *retx = &dhcpv6_retx[type];
+	uint64_t current_milli_time = 0;
 
-	if (!retx->is_retransmit){
+	if (retx->delay ) {
+		if (retx->delay_msec == 0) {
+			retx->delay_msec = (dhcpv6_rand_delay((10000 * DHCPV6_REQ_DELAY) / 2) + (1000 * DHCPV6_REQ_DELAY) / 2);
+			dhcpv6_set_state_timeout(retx->delay_msec);
+			retx->delay_msec += odhcp6c_get_milli_time();
+			return 1;
+		} else {
+			current_milli_time = odhcp6c_get_milli_time();
+			if (current_milli_time < retx->delay_msec) {
+				dhcpv6_set_state_timeout(retx->delay_msec - current_milli_time);
+				return 1;
+			}
+			retx->delay_msec = 0;
+		}
+	}
+
+	if (!retx->is_retransmit) {
 		retx->is_retransmit = true;
 		retx->rc = 0;
 		retx->timeout = UINT32_MAX;
-
-		if (retx->delay) {
-			struct timespec ts = {0, 0};
-			ts.tv_nsec = (dhcpv6_rand_delay((10000 * DHCPV6_REQ_DELAY) / 2) + (1000 * DHCPV6_REQ_DELAY) / 2) * 1000000;
-			while (nanosleep(&ts, &ts) < 0 && errno == EINTR);
-		}
+		retx->reply_ret = -1;
 
 		if (type == DHCPV6_MSG_UNKNOWN)
 			retx->timeout = t1;
@@ -1786,6 +1677,8 @@ int dhcpv6_send_request(enum dhcpv6_msg type)
 	if ((retx->timeout != UINT32_MAX) && (retx->round_end - retx->start > retx->timeout * 1000))
 		retx->round_end = retx->timeout * 1000 + retx->start;
 
+	dhcpv6_set_state_timeout(retx->round_end - odhcp6c_get_milli_time());
+
 	// Built and send package
 	switch (type) {
 	case DHCPV6_MSG_UNKNOWN:
@@ -1799,6 +1692,10 @@ int dhcpv6_send_request(enum dhcpv6_msg type)
 		dhcpv6_send(type, retx->tr_id, elapsed / 10);
 		retx->rc++;
 	}
+	
+	if (dhcpv6_get_state() != DHCPV6_EXIT)
+		dhcpv6_next_state();
+
 	return 0;
 }
 
@@ -1864,4 +1761,32 @@ int dhcpv6_receive_response(enum dhcpv6_msg type)
 		retx->round_end = 1000 + retx->round_start;
 
 	return retx->reply_ret;
+}
+
+int dhcpv6_state_processing(enum dhcpv6_msg type)
+{
+	struct dhcpv6_retx *retx = &dhcpv6_retx[type];
+	int ret = retx->reply_ret;
+	retx->round_start = odhcp6c_get_milli_time();
+	uint64_t elapsed = retx->round_start - retx->start;
+
+	if (retx->round_start >= retx->round_end || ret >=0 ) {
+
+		if (retx->handler_finish)
+			ret = retx->handler_finish();
+		
+		if (ret < 0 && ((retx->timeout == UINT32_MAX) || (elapsed / 1000 < retx->timeout)) &&
+			(!retx->max_rc || retx->rc < retx->max_rc)) {
+				retx->reply_ret = -1;
+				dhcpv6_prev_state();
+		} else {
+			retx->is_retransmit = false;
+			dhcpv6_next_state();
+		}
+	}
+	else{
+		dhcpv6_set_state_timeout(retx->round_end - retx->round_start);
+	}
+
+	return ret;
 }

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -119,6 +119,9 @@ static uint8_t reconf_key[16];
 // client options
 static unsigned int client_options = 0;
 
+// counters for statistics
+static struct dhcpv6_stats dhcpv6_stats = {0};
+
 static uint32_t ntohl_unaligned(const uint8_t *data)
 {
 	uint32_t buf;
@@ -137,6 +140,54 @@ static void dhcpv6_prev_state(void)
 {
 	dhcpv6_state--;
 	dhcpv6_reset_state_timeout();
+}
+
+static void dhcpv6_inc_counter(enum dhcpv6_msg type)
+{
+	switch (type) {
+	case DHCPV6_MSG_SOLICIT:
+		dhcpv6_stats.solicit++;
+		break;
+
+	case DHCPV6_MSG_ADVERT:
+		dhcpv6_stats.advertise++;
+		break;
+
+	case DHCPV6_MSG_REQUEST:
+		dhcpv6_stats.request++;
+		break;
+
+	case DHCPV6_MSG_RENEW:
+		dhcpv6_stats.renew++;
+		break;
+
+	case DHCPV6_MSG_REBIND:
+		dhcpv6_stats.rebind++;
+		break;
+
+	case DHCPV6_MSG_REPLY:
+		dhcpv6_stats.reply++;
+		break;
+
+	case DHCPV6_MSG_RELEASE:
+		dhcpv6_stats.release++;
+		break;
+
+	case DHCPV6_MSG_DECLINE:
+		dhcpv6_stats.decline++;
+		break;
+
+	case DHCPV6_MSG_RECONF:
+		dhcpv6_stats.reconfigure++;
+		break;
+
+	case DHCPV6_MSG_INFO_REQ:
+		dhcpv6_stats.information_request++;
+		break;
+
+	default:
+		break;
+	}
 }
 
 static char *dhcpv6_msg_to_str(enum dhcpv6_msg msg)
@@ -335,6 +386,16 @@ void dhcpv6_set_state_timeout(int timeout)
 void dhcpv6_reset_state_timeout(void)
 {
 	dhcpv6_state_timeout = 0;
+}
+
+struct dhcpv6_stats dhcpv6_get_stats(void)
+{
+	return dhcpv6_stats;
+}
+
+void dhcpv6_reset_stats(void)
+{
+	memset(&dhcpv6_stats, 0, sizeof(dhcpv6_stats));
 }
 
 int init_dhcpv6(const char *ifname, unsigned int options, int sk_prio, int sol_timeout, unsigned int dscp)
@@ -765,6 +826,9 @@ static void dhcpv6_send(enum dhcpv6_msg type, uint8_t trid[3], uint32_t ecs)
 			dhcpv6_msg_to_str(type),
 			inet_ntop(AF_INET6, (const void *)&srv.sin6_addr,
 				in6_str, sizeof(in6_str)), strerror(errno));
+		dhcpv6_stats.transmit_failures++;
+	} else {
+		dhcpv6_inc_counter(type);
 	}
 }
 
@@ -1813,13 +1877,17 @@ int dhcpv6_receive_response(enum dhcpv6_msg type)
 	}
 
 	if (pktinfo == NULL) {
-        	return -1;
+		dhcpv6_stats.discarded_packets++;
+		return -1;
 	}
 
 	if (!dhcpv6_response_is_valid(buf, len, retx->tr_id, type,
 					 &pktinfo->ipi6_addr)) {
+		dhcpv6_stats.discarded_packets++;
 		return -1;
 	}
+
+	dhcpv6_inc_counter(hdr->msg_type);
 
 	uint8_t *opt = &buf[4];
 	uint8_t *opt_end = opt + len - 4;

--- a/src/dhcpv6.c
+++ b/src/dhcpv6.c
@@ -194,7 +194,7 @@ static char *dhcpv6_status_code_to_str(uint16_t code)
 	return "Unknown";
 }
 
-int init_dhcpv6(const char *ifname, unsigned int options, int sk_prio, int sol_timeout)
+int init_dhcpv6(const char *ifname, unsigned int options, int sk_prio, int sol_timeout, unsigned int dscp)
 {
 	client_options = options;
 	dhcpv6_retx[DHCPV6_MSG_SOLICIT].max_timeo = sol_timeout;
@@ -287,6 +287,11 @@ int init_dhcpv6(const char *ifname, unsigned int options, int sk_prio, int sol_t
 
 	if (setsockopt(sock, SOL_SOCKET, SO_PRIORITY, &sk_prio, sizeof(sk_prio)) < 0)
 		goto failure;
+
+	val = dscp << 2;
+	if(setsockopt(sock, IPPROTO_IPV6, IPV6_TCLASS, &val, sizeof(val)) < 0) {
+		goto failure;
+	}
 
 	struct sockaddr_in6 client_addr = { .sin6_family = AF_INET6,
 		.sin6_port = htons(DHCPV6_CLIENT_PORT), .sin6_flowinfo = 0 };

--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -351,6 +351,10 @@ int main(_unused int argc, char* const argv[])
 			break;
 
 		case 'E':
+#ifndef HAVE_UBUS
+			syslog(LOG_ERR, "Failed to use ubus event: ENABLE_UBUS compilation flag missing");
+			return 1;
+#endif
 			script = NULL;
 			break;
 

--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -525,11 +525,12 @@ int main(_unused int argc, char* const argv[])
 			syslog(LOG_NOTICE, "(re)starting transaction on %s", ifname);
 
 			signal_usr1 = signal_usr2 = false;
+
 			dhcpv6_set_state(DHCPV6_SOLICIT);
 			break;
 
 		case DHCPV6_SOLICIT:
-			mode = dhcpv6_set_ia_mode(config_dhcp->ia_na_mode, config_dhcp->ia_pd_mode, config_dhcp->stateful_only_mode);
+			mode = dhcpv6_get_ia_mode();
 			if (mode == DHCPV6_STATELESS) {
 				dhcpv6_set_state(DHCPV6_REQUEST);
 				break;

--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -363,13 +363,11 @@ int main(_unused int argc, char* const argv[])
 			break;
 
 		case 't':
-			config_set_solicit_timeout(atoi(optarg));
+			config_set_rtx_timeout_init(CONFIG_DHCP_SOLICIT, atoi(optarg));
 			break;
 
 		case 'C':
-			if(!config_set_dscp(atoi(optarg))) {
-				syslog(LOG_ERR, "Invalid DSCP value, using default (0)");
-			}
+			config_set_dscp(atoi(optarg));
 			break;
 
 		case 'm':
@@ -517,7 +515,7 @@ int main(_unused int argc, char* const argv[])
 			odhcp6c_get_state(STATE_ORO, &oro_len);
 			config_dhcp->oro_user_cnt = oro_len / sizeof(uint16_t);
 
-			if(init_dhcpv6(ifname, config_dhcp->client_options, config_dhcp->sk_prio, config_dhcp->sol_timeout, config_dhcp->dscp)) {
+			if(init_dhcpv6(ifname)) {
 				syslog(LOG_ERR, "failed to initialize: %s", strerror(errno));
 				return 1;
 			}
@@ -666,9 +664,6 @@ int main(_unused int argc, char* const argv[])
 		case DHCPV6_SOLICIT_PROCESSING:
 		case DHCPV6_REQUEST_PROCESSING:
 			res = dhcpv6_state_processing(msg_type);
-
-			if (signal_usr2 || signal_term)
-				dhcpv6_set_state(DHCPV6_EXIT);
 			break;
 
 		case DHCPV6_BOUND_PROCESSING:
@@ -678,8 +673,6 @@ int main(_unused int argc, char* const argv[])
 
 			if (signal_usr1)
 				dhcpv6_set_state(mode == DHCPV6_STATELESS ? DHCPV6_INFO : DHCPV6_RENEW);
-			if (signal_usr2 || signal_term)
-				dhcpv6_set_state(DHCPV6_EXIT);
 			break;
 		
 		case DHCPV6_RENEW_PROCESSING:
@@ -688,8 +681,6 @@ int main(_unused int argc, char* const argv[])
 
 			if (signal_usr1)
 				signal_usr1 = false;   // Acknowledged
-			if (signal_usr2 || signal_term)
-				dhcpv6_set_state(DHCPV6_EXIT);
 			break;
 		
 		case DHCPV6_EXIT:
@@ -735,6 +726,9 @@ int main(_unused int argc, char* const argv[])
 		default:
 			break;
 		}
+
+		if (signal_usr2 || signal_term)
+			dhcpv6_set_state(DHCPV6_EXIT);
 
 		poll_res = poll(fds, nfds, dhcpv6_get_state_timeout());
 		dhcpv6_reset_state_timeout();

--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -191,7 +191,7 @@ int main(_unused int argc, char* const argv[])
 	config_dhcp = config_dhcp_get();
 	config_dhcp_reset();
 
-	while ((c = getopt(argc, argv, "S::DN:V:P:FB:c:i:r:Ru:Ux:s:kK:t:C:m:Lhedp:fav")) != -1) {
+	while ((c = getopt(argc, argv, "S::DN:V:P:FB:c:i:r:Ru:Ux:s:EkK:t:C:m:Lhedp:fav")) != -1) {
 		switch (c) {
 		case 'S':
 			config_set_allow_slaac_only((optarg) ? atoi(optarg) : -1);
@@ -346,7 +346,12 @@ int main(_unused int argc, char* const argv[])
 			break;
 
 		case 's':
-			script = optarg;
+			if (script)
+				script = optarg;
+			break;
+
+		case 'E':
+			script = NULL;
 			break;
 
 		case 'k':
@@ -779,6 +784,7 @@ static int usage(void)
 	"	-r <options>	Options to be requested (comma-separated)\n"
 	"	-R		Do not request any options except those specified with -r\n"
 	"	-s <script>	Status update script (/usr/sbin/odhcp6c-update)\n"
+	"	-E		Only use UBUS event and disable status update script\n"
 	"	-a		Don't send Accept Reconfigure option\n"
 	"	-f		Don't send Client FQDN option\n"
 	"	-k		Don't send a RELEASE when stopping\n"

--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -37,6 +37,7 @@
 
 #include "odhcp6c.h"
 #include "ra.h"
+#include "config.h"
 
 #ifdef HAVE_UBUS
 #include <libubus.h>
@@ -51,15 +52,9 @@
 	((((__const uint32_t *) (a))[0] & htonl (0xfe000000)) \
 	 == htonl (0xfc000000))
 #endif
-#define ARRAY_SEP " ,\t"
 
 static void sighandler(int signal);
 static int usage(void);
-static int add_opt(const uint16_t code, const uint8_t *data,
-		const uint16_t len);
-static int parse_opt_data(const char *data, uint8_t **dst,
-		const unsigned int type, const bool array);
-static int parse_opt(const char *opt);
 
 static uint8_t *state_data[_STATE_MAX] = {NULL};
 static size_t state_len[_STATE_MAX] = {0};
@@ -69,18 +64,11 @@ static volatile bool signal_usr1 = false;
 static volatile bool signal_usr2 = false;
 static volatile bool signal_term = false;
 
-static int urandom_fd = -1, allow_slaac_only = 0;
-static bool bound = false, release = true, ra = false;
+static int urandom_fd = -1;
+static bool bound = false, ra = false;
 static time_t last_update = 0;
 static char *ifname = NULL;
-static unsigned int dscp = 0;
-static int sol_timeout = DHCPV6_SOL_MAX_RT;
-static int sk_prio = 0;
-bool stateful_only_mode = 0;
-static enum odhcp6c_ia_mode ia_na_mode = IA_MODE_TRY;
-static enum odhcp6c_ia_mode ia_pd_mode = IA_MODE_NONE;
-static unsigned int client_options = DHCPV6_CLIENT_FQDN | DHCPV6_ACCEPT_RECONFIGURE;
-static unsigned int oro_user_cnt = 0;
+struct config_dhcp *config_dhcp = NULL;
 
 static unsigned int script_sync_delay = 10;
 static unsigned int script_accu_delay = 1;
@@ -200,26 +188,21 @@ int main(_unused int argc, char* const argv[])
 	unsigned int ra_options = RA_RDNSS_DEFAULT_LIFETIME;
 	unsigned int ra_holdoff_interval = RA_MIN_ADV_INTERVAL;
 	bool terminate = false;
+	config_dhcp = config_dhcp_get();
+	config_dhcp_reset();
 
 	while ((c = getopt(argc, argv, "S::DN:V:P:FB:c:i:r:Ru:Ux:s:kK:t:C:m:Lhedp:fav")) != -1) {
 		switch (c) {
 		case 'S':
-			allow_slaac_only = (optarg) ? atoi(optarg) : -1;
+			config_set_allow_slaac_only((optarg) ? atoi(optarg) : -1);
 			break;
 
 		case 'D':
-			stateful_only_mode = 1;
+			config_set_stateful_only(true);
 			break;
 
 		case 'N':
-			if (!strcmp(optarg, "force")) {
-				ia_na_mode = IA_MODE_FORCE;
-				allow_slaac_only = -1;
-			} else if (!strcmp(optarg, "none"))
-				ia_na_mode = IA_MODE_NONE;
-			else if (!strcmp(optarg, "try"))
-				ia_na_mode = IA_MODE_TRY;
-			else
+			if (!config_set_request_addresses(optarg))
 				help = true;
 			break;
 
@@ -231,10 +214,10 @@ int main(_unused int argc, char* const argv[])
 			}
 
 			o_data = NULL;
-			res = parse_opt_data(optarg, &o_data, opt->flags & OPT_MASK_SIZE,
+			res = config_parse_opt_data(optarg, &o_data, opt->flags & OPT_MASK_SIZE,
 						(opt->flags & OPT_ARRAY) == OPT_ARRAY);
 			if (res > 0) {
-				res = add_opt(opt->code, o_data, res);
+				res = config_add_opt(opt->code, o_data, res);
 				if (res) {
 					if (res > 0)
 						return 1;
@@ -248,11 +231,11 @@ int main(_unused int argc, char* const argv[])
 			break;
 
 		case 'P':
-			if (ia_pd_mode == IA_MODE_NONE)
-				ia_pd_mode = IA_MODE_TRY;
+			if (config_dhcp->ia_pd_mode == IA_MODE_NONE)
+				config_dhcp->ia_pd_mode = IA_MODE_TRY;
 
-			if (allow_slaac_only >= 0 && allow_slaac_only < 10)
-				allow_slaac_only = 10;
+			if (config_dhcp->allow_slaac_only >= 0 && config_dhcp->allow_slaac_only < 10)
+				config_dhcp->allow_slaac_only = 10;
 
 			struct odhcp6c_request_prefix prefix = { 0 };
 
@@ -291,8 +274,7 @@ int main(_unused int argc, char* const argv[])
 			break;
 
 		case 'F':
-			allow_slaac_only = -1;
-			ia_pd_mode = IA_MODE_FORCE;
+			config_set_force_prefix(true);
 			break;
 
 		case 'c':
@@ -332,7 +314,7 @@ int main(_unused int argc, char* const argv[])
 			break;
 
 		case 'R':
-			client_options |= DHCPV6_STRICT_OPTIONS;
+			config_set_client_options(DHCPV6_STRICT_OPTIONS, true);
 			break;
 
 		case 'u':
@@ -343,10 +325,10 @@ int main(_unused int argc, char* const argv[])
 			}
 
 			o_data = NULL;
-			res = parse_opt_data(optarg, &o_data, opt->flags & OPT_MASK_SIZE,
+			res = config_parse_opt_data(optarg, &o_data, opt->flags & OPT_MASK_SIZE,
 						(opt->flags & OPT_ARRAY) == OPT_ARRAY);
 			if (res > 0) {
-				res = add_opt(opt->code, o_data, res);
+				res = config_add_opt(opt->code, o_data, res);
 				if (res) {
 					if (res > 0)
 						return 1;
@@ -360,7 +342,7 @@ int main(_unused int argc, char* const argv[])
 			break;
 
 		case 'U':
-			client_options |= DHCPV6_IGNORE_OPT_UNICAST;
+			config_set_client_options(DHCPV6_IGNORE_OPT_UNICAST, true);
 			break;
 
 		case 's':
@@ -368,21 +350,19 @@ int main(_unused int argc, char* const argv[])
 			break;
 
 		case 'k':
-			release = false;
+			config_set_release(false);
 			break;
 
 		case 'K':
-			sk_prio = atoi(optarg);
+			config_set_sk_priority(atoi(optarg));
 			break;
 
 		case 't':
-			sol_timeout = atoi(optarg);
+			config_set_solicit_timeout(atoi(optarg));
 			break;
 
 		case 'C':
-			dscp = atoi(optarg);
-			if(dscp > 63) {
-				dscp = 0;
+			if(!config_set_dscp(atoi(optarg))) {
 				syslog(LOG_ERR, "Invalid DSCP value, using default (0)");
 			}
 			break;
@@ -408,11 +388,11 @@ int main(_unused int argc, char* const argv[])
 			break;
 
 		case 'f':
-			client_options &= ~DHCPV6_CLIENT_FQDN;
+			config_set_client_options(DHCPV6_CLIENT_FQDN, false);
 			break;
 
 		case 'a':
-			client_options &= ~DHCPV6_ACCEPT_RECONFIGURE;
+			config_set_client_options(DHCPV6_ACCEPT_RECONFIGURE, false);
 			break;
 
 		case 'v':
@@ -420,7 +400,7 @@ int main(_unused int argc, char* const argv[])
 			break;
 
 		case 'x':
-			res = parse_opt(optarg);
+			res = config_parse_opt(optarg);
 			if (res) {
 				if (res > 0)
 					return res;
@@ -435,8 +415,8 @@ int main(_unused int argc, char* const argv[])
 		}
 	}
 
-	if (allow_slaac_only > 0)
-		script_sync_delay = allow_slaac_only;
+	if (config_dhcp->allow_slaac_only > 0)
+		script_sync_delay = config_dhcp->allow_slaac_only;
 
 	openlog("odhcp6c", logopt, LOG_DAEMON);
 	if (!verbosity)
@@ -530,11 +510,9 @@ int main(_unused int argc, char* const argv[])
 
 			size_t oro_len = 0;
 			odhcp6c_get_state(STATE_ORO, &oro_len);
-			oro_user_cnt = oro_len / sizeof(uint16_t);
+			config_dhcp->oro_user_cnt = oro_len / sizeof(uint16_t);
 
-			syslog(LOG_NOTICE, "number of user requested options %u", oro_user_cnt);
-
-			if(init_dhcpv6(ifname, client_options, sk_prio, sol_timeout, dscp)) {
+			if(init_dhcpv6(ifname, config_dhcp->client_options, config_dhcp->sk_prio, config_dhcp->sol_timeout, config_dhcp->dscp)) {
 				syslog(LOG_ERR, "failed to initialize: %s", strerror(errno));
 				return 1;
 			}
@@ -548,7 +526,7 @@ int main(_unused int argc, char* const argv[])
 			break;
 
 		case DHCPV6_SOLICIT:
-			mode = dhcpv6_set_ia_mode(ia_na_mode, ia_pd_mode, stateful_only_mode);
+			mode = dhcpv6_set_ia_mode(config_dhcp->ia_na_mode, config_dhcp->ia_pd_mode, config_dhcp->stateful_only_mode);
 			if (mode == DHCPV6_STATELESS) {
 				dhcpv6_set_state(DHCPV6_REQUEST);
 				break;
@@ -564,7 +542,7 @@ int main(_unused int argc, char* const argv[])
 				dhcpv6_set_state(DHCPV6_REQUEST);
 			} else {
 				mode = DHCPV6_UNKNOWN;
-				dhcpv6_set_state(DHCPV6_INIT);
+				dhcpv6_set_state(DHCPV6_RESET);
 			}
 			break;
 
@@ -581,12 +559,12 @@ int main(_unused int argc, char* const argv[])
 
 			if ((res < 0) && signalled) {
 				mode = DHCPV6_UNKNOWN;
-				dhcpv6_set_state(DHCPV6_INIT);
+				dhcpv6_set_state(DHCPV6_RESET);
 				break;
 			}
 
 			mode = dhcpv6_promote_server_cand();
-			dhcpv6_set_state(mode > DHCPV6_UNKNOWN ? DHCPV6_REQUEST : DHCPV6_INIT);
+			dhcpv6_set_state(mode > DHCPV6_UNKNOWN ? DHCPV6_REQUEST : DHCPV6_RESET);
 			break;
 
 		case DHCPV6_BOUND:
@@ -721,7 +699,7 @@ int main(_unused int argc, char* const argv[])
 			bound = false;
 			notify_state_change("unbound", 0, true);
 
-			if (server_id_len > 0 && (ia_pd_len > 0 || ia_na_len > 0) && release)
+			if (server_id_len > 0 && (ia_pd_len > 0 || ia_na_len > 0) && config_dhcp->release)
 				dhcpv6_send_request(DHCPV6_MSG_RELEASE);
 
 			odhcp6c_clear_state(STATE_IA_NA);
@@ -740,7 +718,7 @@ int main(_unused int argc, char* const argv[])
 
 			size_t oro_user_len, oro_total_len;
 			odhcp6c_get_state(STATE_ORO, &oro_total_len);
-			oro_user_len = oro_user_cnt * sizeof(uint16_t);
+			oro_user_len = config_dhcp->oro_user_cnt * sizeof(uint16_t);
 			odhcp6c_remove_state(STATE_ORO, oro_user_len, oro_total_len - oro_user_len);
 
 			close(dhcpv6_get_socket());
@@ -861,7 +839,7 @@ bool odhcp6c_signal_process(void)
 			ra = false;
 		}
 
-		if (ra_updated && (bound || allow_slaac_only >= 0)) {
+		if (ra_updated && (bound || config_dhcp->allow_slaac_only >= 0)) {
 			notify_state_change("ra-updated", (!ra && !bound) ?
 					script_sync_delay : script_accu_delay, false);
 			ra = true;
@@ -1018,20 +996,6 @@ static void odhcp6c_expire_list(enum odhcp6c_state state, uint32_t elapsed, bool
 	}
 }
 
-static uint8_t *odhcp6c_state_find_opt(const uint16_t code)
-{
-	size_t opts_len;
-	uint8_t *odata, *opts = odhcp6c_get_state(STATE_OPTS, &opts_len);
-	uint16_t otype, olen;
-
-	dhcpv6_for_each_option(opts, &opts[opts_len], otype, olen, odata) {
-		if (otype == code)
-			return &odata[-4];
-	}
-
-	return NULL;
-}
-
 void odhcp6c_expire(bool expire_ia_pd)
 {
 	time_t now = odhcp6c_get_milli_time() / 1000;
@@ -1130,23 +1094,12 @@ static void sighandler(int signal)
 		signal_term = true;
 }
 
-static int add_opt(const uint16_t code, const uint8_t *data, const uint16_t len)
+void notify_state_change(const char *status, int delay, bool resume)
 {
-	struct {
-		uint16_t code;
-		uint16_t len;
-	} opt_hdr = { htons(code), htons(len) };
-
-	if (odhcp6c_state_find_opt(code))
-		return -1;
-
-	if (odhcp6c_add_state(STATE_OPTS, &opt_hdr, sizeof(opt_hdr)) ||
-			odhcp6c_add_state(STATE_OPTS, data, len)) {
-		syslog(LOG_ERR, "Failed to add option %hu", code);
-		return 1;
-	}
-
-	return 0;
+	script_call(status, delay, resume);
+#ifdef HAVE_UBUS
+	ubus_dhcp_event(status);
+#endif
 }
 
 struct odhcp6c_opt *odhcp6c_find_opt(const uint16_t code)
@@ -1163,7 +1116,7 @@ struct odhcp6c_opt *odhcp6c_find_opt(const uint16_t code)
 	return NULL;
 }
 
-static struct odhcp6c_opt *odhcp6c_find_opt_by_name(const char *name)
+struct odhcp6c_opt *odhcp6c_find_opt_by_name(const char *name)
 {
 	struct odhcp6c_opt *opt = opts;
 
@@ -1174,358 +1127,4 @@ static struct odhcp6c_opt *odhcp6c_find_opt_by_name(const char *name)
 		opt++;
 
 	return (opt->code > 0 ? opt : NULL);
-}
-
-static int parse_opt_u8(const char *src, uint8_t **dst)
-{
-	int len = strlen(src);
-
-	*dst = realloc(*dst, len/2);
-	if (!*dst)
-		return -1;
-
-	return script_unhexlify(*dst, len, src);
-}
-
-static int parse_opt_string(const char *src, uint8_t **dst, const bool array)
-{
-	int o_len = 0;
-	char *sep = strpbrk(src, ARRAY_SEP);
-
-	if (sep && !array)
-		return -1;
-
-	do {
-		if (sep) {
-			*sep = 0;
-			sep++;
-		}
-
-		int len = strlen(src);
-
-		*dst = realloc(*dst, o_len + len);
-		if (!*dst)
-			return -1;
-
-		memcpy(&((*dst)[o_len]), src, len);
-
-		o_len += len;
-		src = sep;
-
-		if (sep)
-			sep = strpbrk(src, ARRAY_SEP);
-	} while (src);
-
-	return o_len;
-}
-
-static int parse_opt_dns_string(const char *src, uint8_t **dst, const bool array)
-{
-	int o_len = 0;
-	char *sep = strpbrk(src, ARRAY_SEP);
-
-	if (sep && !array)
-		return -1;
-
-	do {
-		uint8_t tmp[256];
-
-		if (sep) {
-			*sep = 0;
-			sep++;
-		}
-
-		int len = dn_comp(src, tmp, sizeof(tmp), NULL, NULL);
-		if (len < 0)
-			return -1;
-
-		*dst = realloc(*dst, o_len + len);
-		if (!*dst)
-			return -1;
-
-		memcpy(&((*dst)[o_len]), tmp, len);
-
-		o_len += len;
-		src = sep;
-
-		if (sep)
-			sep = strpbrk(src, ARRAY_SEP);
-	} while (src);
-
-	return o_len;
-}
-
-static int parse_opt_ip6(const char *src, uint8_t **dst, const bool array)
-{
-	int o_len = 0;
-	char *sep = strpbrk(src, ARRAY_SEP);
-
-	if (sep && !array)
-		return -1;
-
-	do {
-		int len = sizeof(struct in6_addr);
-
-		if (sep) {
-			*sep = 0;
-			sep++;
-		}
-
-		*dst = realloc(*dst, o_len + len);
-		if (!*dst)
-			return -1;
-
-		if (inet_pton(AF_INET6, src, &((*dst)[o_len])) < 1)
-			return -1;
-
-		o_len += len;
-		src = sep;
-
-		if (sep)
-			sep = strpbrk(src, ARRAY_SEP);
-	} while (src);
-
-	return o_len;
-}
-
-static int parse_opt_user_class(const char *src, uint8_t **dst, const bool array)
-{
-	int o_len = 0;
-	char *sep = strpbrk(src, ARRAY_SEP);
-
-	if (sep && !array)
-		return -1;
-
-	do {
-		if (sep) {
-			*sep = 0;
-			sep++;
-		}
-		uint16_t str_len = strlen(src);
-
-		*dst = realloc(*dst, o_len + str_len + 2);
-		if (!*dst)
-			return -1;
-
-		struct user_class {
-			uint16_t len;
-			uint8_t data[];
-		} *e = (struct user_class *)&((*dst)[o_len]);
-
-		e->len = ntohs(str_len);
-		memcpy(e->data, src, str_len);
-
-		o_len += str_len + 2;
-		src = sep;
-
-		if (sep)
-			sep = strpbrk(src, ARRAY_SEP);
-	} while (src);
-
-	return o_len;
-}
-
-static int parse_opt_data(const char *data, uint8_t **dst, const unsigned int type,
-		const bool array)
-{
-	int ret = 0;
-
-	switch (type) {
-	case OPT_U8:
-		ret = parse_opt_u8(data, dst);
-		break;
-
-	case OPT_STR:
-		ret = parse_opt_string(data, dst, array);
-		break;
-
-	case OPT_DNS_STR:
-		ret = parse_opt_dns_string(data, dst, array);
-		break;
-
-	case OPT_IP6:
-		ret = parse_opt_ip6(data, dst, array);
-		break;
-
-	case OPT_USER_CLASS:
-		ret = parse_opt_user_class(data, dst, array);
-		break;
-
-	default:
-		ret = -1;
-		break;
-	}
-
-	return ret;
-}
-
-static int parse_opt(const char *opt)
-{
-	uint32_t optn;
-	char *data;
-	uint8_t *payload = NULL;
-	int payload_len;
-	unsigned int type = OPT_U8;
-	bool array = false;
-	struct odhcp6c_opt *dopt = NULL;
-	int ret = -1;
-
-	data = strpbrk(opt, ":");
-	if (!data)
-		return -1;
-
-	*data = '\0';
-	data++;
-
-	if (strlen(opt) == 0 || strlen(data) == 0)
-		return -1;
-
-	dopt = odhcp6c_find_opt_by_name(opt);
-	if (!dopt) {
-		char *e;
-		optn = strtoul(opt, &e, 0);
-		if (*e || e == opt || optn > USHRT_MAX)
-			return -1;
-
-		dopt = odhcp6c_find_opt(optn);
-	} else
-		optn = dopt->code;
-
-	/* Check if the type for the content is well-known */
-	if (dopt) {
-		/* Refuse internal options */
-		if (dopt->flags & OPT_INTERNAL)
-			return -1;
-
-		type = dopt->flags & OPT_MASK_SIZE;
-		array = ((dopt->flags & OPT_ARRAY) == OPT_ARRAY) ? true : false;
-	} else if (data[0] == '"' || data[0] == '\'') {
-		char *end = strrchr(data + 1, data[0]);
-
-		if (end && (end == (data + strlen(data) - 1))) {
-			/* Raw option is specified as a string */
-			type = OPT_STR;
-			data++;
-			*end = '\0';
-		}
-
-	}
-
-	payload_len = parse_opt_data(data, &payload, type, array);
-	if (payload_len > 0)
-		ret = add_opt(optn, payload, payload_len);
-
-	free(payload);
-
-	return ret;
-}
-
-void notify_state_change(const char *status, int delay, bool resume)
-{
-	script_call(status, delay, resume);
-#ifdef HAVE_UBUS
-	ubus_dhcp_event(status);
-#endif
-}
-
-void config_set_release(bool enable) {
-	release = enable;
-}
-
-bool config_set_dscp(unsigned int value) {
-	if(value > 63)
-		return false;
-	dscp = value;
-	return true;
-}
-
-bool config_set_solicit_timeout(unsigned int timeout) {
-	if(timeout > INT32_MAX)
-		return false;
-
-	sol_timeout = timeout;
-	return true;
-}
-
-bool config_set_sk_priority(unsigned int priority) {
-	if(priority > 6)
-		return false;
-
-	sk_prio = priority;
-	return true;
-}
-
-void config_set_client_options(enum dhcpv6_config option, bool enable) {
-	if(enable) {
-		client_options |= option;
-	} else {
-		client_options &= ~option;
-	}
-}
-
-bool config_set_request_addresses(char* mode) {
-	if (!strcmp(mode, "force")) {
-		ia_na_mode = IA_MODE_FORCE;
-		allow_slaac_only = -1;
-	} else if (!strcmp(mode, "none"))
-		ia_na_mode = IA_MODE_NONE;
-	else if (!strcmp(mode, "try"))
-		ia_na_mode = IA_MODE_TRY;
-	else
-		return false;
-
-	return true;
-}
-
-bool config_set_request_prefix(unsigned int length, unsigned int id) {
-	struct odhcp6c_request_prefix prefix = {0};
-
-	odhcp6c_clear_state(STATE_IA_PD_INIT);
-
-	if (ia_pd_mode != IA_MODE_FORCE)
-		ia_pd_mode = length > 128 ? IA_MODE_NONE : IA_MODE_TRY;
-
-	if(length <= 128) {
-		if (allow_slaac_only >= 0 && allow_slaac_only < 10)
-			allow_slaac_only = 10;
-
-		prefix.length = length;
-		prefix.iaid = htonl(id);
-
-		if (odhcp6c_add_state(STATE_IA_PD_INIT, &prefix, sizeof(prefix))) {
-			syslog(LOG_ERR, "Failed to set request IPv6-Prefix");
-			return false;
-		}
-	}
-
-	return true;
-}
-
-void config_set_stateful_only(bool enable) {
-	stateful_only_mode = enable;
-}
-
-void config_clear_requested_options(void) {
-	oro_user_cnt = 0;
-}
-
-bool config_add_requested_options(unsigned int option) {
-	if(option > UINT16_MAX)
-		return false;
-
-	option = htons(option);
-	if (odhcp6c_insert_state(STATE_ORO, 0, &option, 2)) {
-		syslog(LOG_ERR, "Failed to add requested option");
-		return false;
-	}
-	oro_user_cnt++;
-	return true;
-}
-
-void config_clear_send_options(void) {
-	odhcp6c_clear_state(STATE_OPTS);
-}
-
-bool config_add_send_options(char* option) {
-	return (parse_opt(option) == 0);
 }

--- a/src/odhcp6c.c
+++ b/src/odhcp6c.c
@@ -31,6 +31,7 @@
 
 #include <net/if.h>
 #include <sys/syscall.h>
+#include <poll.h>
 #include <arpa/inet.h>
 #include <linux/if_addr.h>
 
@@ -183,11 +184,13 @@ int main(_unused int argc, char* const argv[])
 	int verbosity = 0;
 	bool help = false, daemonize = false;
 	int logopt = LOG_PID;
-	int c, res;
+	int c;
+	int res = -1;
 	unsigned int client_options = DHCPV6_CLIENT_FQDN | DHCPV6_ACCEPT_RECONFIGURE;
 	unsigned int ra_options = RA_RDNSS_DEFAULT_LIFETIME;
 	unsigned int ra_holdoff_interval = RA_MIN_ADV_INTERVAL;
 	unsigned int dscp = 0;
+	bool terminate = false;
 
 	while ((c = getopt(argc, argv, "S::DN:V:P:FB:c:i:r:Ru:Ux:s:kK:t:C:m:Lhedp:fav")) != -1) {
 		switch (c) {
@@ -470,133 +473,232 @@ int main(_unused int argc, char* const argv[])
 		}
 	}
 
+	struct pollfd fds[2] = {0};
+	int nfds = 0;
+
+	int dhcpv6_socket = dhcpv6_get_socket();
+	int mode = DHCPV6_UNKNOWN;
+	enum dhcpv6_msg msg_type = DHCPV6_MSG_UNKNOWN;
+
+	if (dhcpv6_socket < 0) {
+		syslog(LOG_ERR, "Invalid dhcpv6 file descriptor");
+		return 1;
+	}
+	
+	fds[nfds].fd = dhcpv6_socket;
+	fds[nfds].events = POLLIN;
+	nfds++;
+
 	script_call("started", 0, false);
 
-	while (!signal_term) { // Main logic
-		odhcp6c_clear_state(STATE_SERVER_ID);
-		odhcp6c_clear_state(STATE_SERVER_ADDR);
-		odhcp6c_clear_state(STATE_IA_NA);
-		odhcp6c_clear_state(STATE_IA_PD);
-		odhcp6c_clear_state(STATE_SNTP_IP);
-		odhcp6c_clear_state(STATE_NTP_IP);
-		odhcp6c_clear_state(STATE_NTP_FQDN);
-		odhcp6c_clear_state(STATE_SIP_IP);
-		odhcp6c_clear_state(STATE_SIP_FQDN);
-		bound = false;
+	while (!terminate) { // Main logic
+		int poll_res;
+		bool signalled = odhcp6c_signal_process(); 
 
-		syslog(LOG_NOTICE, "(re)starting transaction on %s", ifname);
+		switch (dhcpv6_get_state()) {
+		case DHCPV6_INIT:
+			odhcp6c_clear_state(STATE_SERVER_ID);
+			odhcp6c_clear_state(STATE_SERVER_ADDR);
+			odhcp6c_clear_state(STATE_IA_NA);
+			odhcp6c_clear_state(STATE_IA_PD);
+			odhcp6c_clear_state(STATE_SNTP_IP);
+			odhcp6c_clear_state(STATE_NTP_IP);
+			odhcp6c_clear_state(STATE_NTP_FQDN);
+			odhcp6c_clear_state(STATE_SIP_IP);
+			odhcp6c_clear_state(STATE_SIP_FQDN);
+			bound = false;
 
-		signal_usr1 = signal_usr2 = false;
-		int mode = dhcpv6_set_ia_mode(ia_na_mode, ia_pd_mode, stateful_only_mode);
-		if (mode != DHCPV6_STATELESS)
-			mode = dhcpv6_request(DHCPV6_MSG_SOLICIT);
+			syslog(LOG_NOTICE, "(re)starting transaction on %s", ifname);
 
-		odhcp6c_signal_process();
+			signal_usr1 = signal_usr2 = false;
+			dhcpv6_set_state(DHCPV6_SOLICIT);
+			break;
 
-		if (mode < 0)
-			continue;
-
-		do {
-			res = dhcpv6_request(mode == DHCPV6_STATELESS ?
-					DHCPV6_MSG_INFO_REQ : DHCPV6_MSG_REQUEST);
-			bool signalled = odhcp6c_signal_process();
-
-			if (res > 0)
+		case DHCPV6_SOLICIT:
+			mode = dhcpv6_set_ia_mode(ia_na_mode, ia_pd_mode, stateful_only_mode);
+			if (mode == DHCPV6_STATELESS) {
+				dhcpv6_set_state(DHCPV6_REQUEST);
 				break;
-			else if (signalled) {
-				mode = -1;
+			}
+			
+			msg_type = DHCPV6_MSG_SOLICIT;
+			dhcpv6_send_request(msg_type);		
+			break;
+
+		case DHCPV6_ADVERT:
+			if(res > 0) {
+				mode = DHCPV6_STATEFUL;
+				dhcpv6_set_state(DHCPV6_REQUEST);
+			} else {
+				mode = DHCPV6_UNKNOWN;
+				dhcpv6_set_state(DHCPV6_INIT);
+			}
+			break;
+
+		case DHCPV6_REQUEST:
+			msg_type = (mode == DHCPV6_STATELESS) ? DHCPV6_MSG_INFO_REQ : DHCPV6_MSG_REQUEST;
+			dhcpv6_send_request(msg_type);
+			break;
+
+		case DHCPV6_REPLY:
+			if ((res > 0) && mode != DHCPV6_UNKNOWN) {
+				dhcpv6_set_state(DHCPV6_BOUND);
+				break;
+			}
+
+			if ((res < 0) && signalled) {
+				mode = DHCPV6_UNKNOWN;
+				dhcpv6_set_state(DHCPV6_INIT);
 				break;
 			}
 
 			mode = dhcpv6_promote_server_cand();
-		} while (mode > DHCPV6_UNKNOWN);
+			dhcpv6_set_state(mode > DHCPV6_UNKNOWN ? DHCPV6_REQUEST : DHCPV6_INIT);
+			break;
 
-		if (mode < 0)
-			continue;
-
-		switch (mode) {
-		case DHCPV6_STATELESS:
-			bound = true;
-			syslog(LOG_NOTICE, "entering stateless-mode on %s", ifname);
-
-			while (!signal_usr2 && !signal_term) {
-				signal_usr1 = false;
-				script_call("informed", script_sync_delay, true);
-
-				res = dhcpv6_poll_reconfigure();
-				odhcp6c_signal_process();
-
-				if (res > 0)
-					continue;
-
-				if (signal_usr1) {
-					signal_usr1 = false; // Acknowledged
-					continue;
+		case DHCPV6_BOUND:
+			if (!bound) {
+				bound = true;
+				if (mode == DHCPV6_STATELESS) {
+					syslog(LOG_NOTICE, "entering stateless-mode on %s", ifname);
+					signal_usr1 = false;
+					script_call("informed", script_sync_delay, true);
+				} else {
+					script_call("bound", script_sync_delay, true);
+					syslog(LOG_NOTICE, "entering stateful-mode on %s", ifname);
 				}
+			}
 
-				if (signal_usr2 || signal_term)
-					break;
-
-				res = dhcpv6_request(DHCPV6_MSG_INFO_REQ);
-				odhcp6c_signal_process();
-
-				if (signal_usr1)
-					continue;
-				else if (res < 0)
-					break;
+			msg_type = DHCPV6_MSG_UNKNOWN;
+			dhcpv6_send_request(msg_type);
+			break;
+		
+		case DHCPV6_BOUND_REPLY:
+			if (res == DHCPV6_MSG_RENEW || res == DHCPV6_MSG_REBIND ||
+				res == DHCPV6_MSG_INFO_REQ) {
+				msg_type = res;
+				dhcpv6_set_state(DHCPV6_RECONF);			
+			} else {
+				dhcpv6_set_state(DHCPV6_RECONF_REPLY);
 			}
 			break;
 
-		case DHCPV6_STATEFUL:
-			bound = true;
-			script_call("bound", script_sync_delay, true);
-			syslog(LOG_NOTICE, "entering stateful-mode on %s", ifname);
+		case DHCPV6_RECONF:	
+			dhcpv6_send_request(msg_type);
+			break;
 
-			while (!signal_usr2 && !signal_term) {
-				// Renew Cycle
-				// Wait for T1 to expire or until we get a reconfigure
-				res = dhcpv6_poll_reconfigure();
-				odhcp6c_signal_process();
-				if (res > 0) {
+		case DHCPV6_RECONF_REPLY:
+			if (res > 0) {
+				dhcpv6_set_state(DHCPV6_BOUND);
+				if (mode == DHCPV6_STATEFUL)
 					script_call("updated", 0, false);
-					continue;
-				}
+			} else {
+				dhcpv6_set_state(mode == DHCPV6_STATELESS ? DHCPV6_INFO : DHCPV6_RENEW);
+			}
+			break;
+		
+		case DHCPV6_RENEW:
+			msg_type = DHCPV6_MSG_RENEW;
+			dhcpv6_send_request(msg_type);
+			break;
+		
+		case DHCPV6_RENEW_REPLY:
+			if (res > 0 ) {
+				script_call("updated", 0, false);
+				dhcpv6_set_state(DHCPV6_BOUND);
+			} else {
+				dhcpv6_set_state(DHCPV6_REBIND);
+			}
+			break;
 
-				// Handle signal, if necessary
-				if (signal_usr1)
-					signal_usr1 = false; // Acknowledged
+		case DHCPV6_REBIND:
+			odhcp6c_clear_state(STATE_SERVER_ID); // Remove binding
+			odhcp6c_clear_state(STATE_SERVER_ADDR);
 
-				if (signal_usr2 || signal_term)
-					break; // Other signal type
+			size_t ia_pd_len_r, ia_na_len_r;
+			odhcp6c_get_state(STATE_IA_PD, &ia_pd_len_r);
+			odhcp6c_get_state(STATE_IA_NA, &ia_na_len_r);
 
-				// Send renew as T1 expired
-				res = dhcpv6_request(DHCPV6_MSG_RENEW);
-				odhcp6c_signal_process();
+			if (ia_pd_len_r == 0 && ia_na_len_r == 0) {
+				dhcpv6_set_state(DHCPV6_EXIT);
+				break;
+			}
 
-				if (res > 0) { // Renew was succesfull
-					// Publish updates
-					script_call("updated", 0, false);
-					continue; // Renew was successful
-				}
+			// If we have IAs, try rebind otherwise restart
+			msg_type = DHCPV6_MSG_REBIND;
+			dhcpv6_send_request(msg_type);
+			break;
+		
+		case DHCPV6_REBIND_REPLY:
+			if (res < 0) {
+				dhcpv6_set_state(DHCPV6_EXIT);
+			} else {
+				script_call("rebound", 0, true);
+				dhcpv6_set_state(DHCPV6_BOUND);
+			}
+			break;
 
-				odhcp6c_clear_state(STATE_SERVER_ID); // Remove binding
-				odhcp6c_clear_state(STATE_SERVER_ADDR);
+		case DHCPV6_INFO:
+			msg_type = DHCPV6_MSG_INFO_REQ;
+			dhcpv6_send_request(msg_type);
+			break;
+		
+		case DHCPV6_INFO_REPLY:
+			dhcpv6_set_state(res < 0 ? DHCPV6_EXIT : DHCPV6_BOUND);
+			break;
 
-				size_t ia_pd_len, ia_na_len;
-				odhcp6c_get_state(STATE_IA_PD, &ia_pd_len);
-				odhcp6c_get_state(STATE_IA_NA, &ia_na_len);
+		case DHCPV6_SOLICIT_PROCESSING:
+		case DHCPV6_REQUEST_PROCESSING:
+			res = dhcpv6_state_processing(msg_type);
 
-				if (ia_pd_len == 0 && ia_na_len == 0)
-					break;
+			if (signal_usr2 || signal_term)
+				dhcpv6_set_state(DHCPV6_EXIT);
+			break;
 
-				// If we have IAs, try rebind otherwise restart
-				res = dhcpv6_request(DHCPV6_MSG_REBIND);
-				odhcp6c_signal_process();
+		case DHCPV6_BOUND_PROCESSING:
+		case DHCPV6_RECONF_PROCESSING:
+		case DHCPV6_REBIND_PROCESSING:
+			res = dhcpv6_state_processing(msg_type);
 
-				if (res > 0)
-					script_call("rebound", 0, true);
-				else
-					break;
+			if (signal_usr1)
+				dhcpv6_set_state(mode == DHCPV6_STATELESS ? DHCPV6_INFO : DHCPV6_RENEW);
+			if (signal_usr2 || signal_term)
+				dhcpv6_set_state(DHCPV6_EXIT);
+			break;
+		
+		case DHCPV6_RENEW_PROCESSING:
+		case DHCPV6_INFO_PROCESSING:
+			res = dhcpv6_state_processing(msg_type);
+
+			if (signal_usr1)
+				signal_usr1 = false;   // Acknowledged
+			if (signal_usr2 || signal_term)
+				dhcpv6_set_state(DHCPV6_EXIT);
+			break;
+		
+		case DHCPV6_EXIT:
+			odhcp6c_expire(false);
+
+			size_t ia_pd_len, ia_na_len, server_id_len;
+			odhcp6c_get_state(STATE_IA_PD, &ia_pd_len);
+			odhcp6c_get_state(STATE_IA_NA, &ia_na_len);
+			odhcp6c_get_state(STATE_SERVER_ID, &server_id_len);
+
+			// Add all prefixes to lost prefixes
+			bound = false;
+			script_call("unbound", 0, true);
+
+			if (server_id_len > 0 && (ia_pd_len > 0 || ia_na_len > 0) && release)
+				dhcpv6_send_request(DHCPV6_MSG_RELEASE);
+
+			odhcp6c_clear_state(STATE_IA_NA);
+			odhcp6c_clear_state(STATE_IA_PD);
+
+			if (!signal_usr2) {
+				terminate = true;
+			} else {
+				signal_usr2 = false;
+				dhcpv6_set_state(DHCPV6_INIT);
 			}
 			break;
 
@@ -604,24 +706,16 @@ int main(_unused int argc, char* const argv[])
 			break;
 		}
 
-		odhcp6c_expire(false);
+		poll_res = poll(fds, nfds, dhcpv6_get_state_timeout());
+		dhcpv6_reset_state_timeout();
+		if (poll_res == -1 && (errno == EINTR || errno == EAGAIN)) {
+			continue;
+		}
 
-		size_t ia_pd_len, ia_na_len, server_id_len;
-		odhcp6c_get_state(STATE_IA_PD, &ia_pd_len);
-		odhcp6c_get_state(STATE_IA_NA, &ia_na_len);
-		odhcp6c_get_state(STATE_SERVER_ID, &server_id_len);
+		if (fds[0].revents & POLLIN)
+			dhcpv6_receive_response(msg_type);
 
-		// Add all prefixes to lost prefixes
-		bound = false;
-		script_call("unbound", 0, true);
-
-		if (server_id_len > 0 && (ia_pd_len > 0 || ia_na_len > 0) && release)
-			dhcpv6_request(DHCPV6_MSG_RELEASE);
-
-		odhcp6c_clear_state(STATE_IA_NA);
-		odhcp6c_clear_state(STATE_IA_PD);
 	}
-
 	script_call("stopped", 0, true);
 
 	return 0;

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -279,13 +279,17 @@ struct dhcpv6_duid {
 	uint8_t data[128];
 } _packed;
 
-struct dhcpv6_auth_reconfigure {
+struct dhcpv6_auth {
 	uint16_t type;
 	uint16_t len;
 	uint8_t protocol;
 	uint8_t algorithm;
 	uint8_t rdm;
 	uint64_t replay;
+	uint8_t data[];
+} _packed;
+
+struct dhcpv6_auth_reconfigure {
 	uint8_t reconf_type;
 	uint8_t key[16];
 } _packed;
@@ -414,6 +418,21 @@ enum odhcp6c_ia_mode {
 	IA_MODE_FORCE,
 };
 
+enum odhcp6c_auth_protocol {
+	AUTH_PROT_NONE = -1,
+	AUTH_PROT_TOKEN = 0,
+	AUTH_PROT_RKAP = 3,
+};
+
+enum odhcp6c_auth_algorithm {
+	AUTH_ALG_TOKEN = 0,
+	AUTH_ALG_HMACMD5 = 1
+};
+
+enum odhcp6c_rkap_type {
+	RKAP_TYPE_KEY = 1,
+	RKAP_TYPE_HMACMD5 = 2,
+};
 
 struct odhcp6c_entry {
 	struct in6_addr router;

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -466,7 +466,7 @@ struct odhcp6c_opt {
 };
 
 int init_dhcpv6(const char *ifname);
-int dhcpv6_set_ia_mode(enum odhcp6c_ia_mode na, enum odhcp6c_ia_mode pd, bool stateful_only);
+int dhcpv6_get_ia_mode(void);
 int dhcpv6_promote_server_cand(void);
 int dhcpv6_send_request(enum dhcpv6_msg type);
 int dhcpv6_receive_response(enum dhcpv6_msg type);

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -26,12 +26,32 @@
 #define ND_OPT_RECURSIVE_DNS 25
 #define ND_OPT_DNSSL 31
 
+#define DHCPV6_MAX_DELAY 1
+#define DHCPV6_IRT_DEFAULT 86400
+#define DHCPV6_IRT_MIN 600
+#define DHCPV6_RAND_FACTOR 100
+
+#define DHCPV6_SOL_INIT_RT 1
 #define DHCPV6_SOL_MAX_RT 120
+
+#define DHCPV6_REQ_INIT_RT 1
 #define DHCPV6_REQ_MAX_RT 30
-#define DHCPV6_CNF_MAX_RT 4
+#define DHCPV6_REQ_MAX_RC 10
+
+#define DHCPV6_REN_INIT_RT 10
 #define DHCPV6_REN_MAX_RT 600
+
+#define DHCPV6_REB_INIT_RT 10
 #define DHCPV6_REB_MAX_RT 600
-#define DHCPV6_INF_MAX_RT 120
+
+#define DHCPV6_INF_INIT_RT 1
+#define DHCPV6_INF_MAX_RT 3600
+
+#define DHCPV6_REL_INIT_RT 1
+#define DHCPV6_REL_MAX_RC 4
+
+#define DHCPV6_DEC_INIT_RT 1
+#define DHCPV6_DEC_MAX_RC 4
 
 #define RA_MIN_ADV_INTERVAL 3   /* RFC 4861 paragraph 6.2.1 */
 
@@ -202,7 +222,7 @@ typedef int(reply_handler)(enum dhcpv6_msg orig, const int rc,
 
 // retransmission strategy
 struct dhcpv6_retx {
-	bool delay;
+	uint8_t max_delay;
 	uint8_t init_timeo;
 	uint16_t max_timeo;
 	uint8_t max_rc;
@@ -445,7 +465,7 @@ struct odhcp6c_opt {
 	const char *str;
 };
 
-int init_dhcpv6(const char *ifname, unsigned int client_options, int sk_prio, int sol_timeout, unsigned int dscp);
+int init_dhcpv6(const char *ifname);
 int dhcpv6_set_ia_mode(enum odhcp6c_ia_mode na, enum odhcp6c_ia_mode pd, bool stateful_only);
 int dhcpv6_promote_server_cand(void);
 int dhcpv6_send_request(enum dhcpv6_msg type);
@@ -471,19 +491,6 @@ int ra_get_reachable(void);
 int ra_get_retransmit(void);
 
 void notify_state_change(const char *status, int delay, bool resume);
-
-void config_set_release(bool enable);
-bool config_set_dscp(unsigned int value);
-bool config_set_solicit_timeout(unsigned int timeout);
-bool config_set_sk_priority(unsigned int value);
-void config_set_client_options(enum dhcpv6_config option, bool enable);
-bool config_set_request_addresses(char *mode);
-bool config_set_request_prefix(unsigned int length, unsigned int id);
-void config_set_stateful_only(bool enable);
-void config_clear_requested_options(void);
-bool config_add_requested_options(unsigned int option);
-void config_clear_send_options(void);
-bool config_add_send_options(char *option);
 
 int script_init(const char *path, const char *ifname);
 ssize_t script_unhexlify(uint8_t *dst, size_t len, const char *src);

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -451,8 +451,11 @@ int ra_get_mtu(void);
 int ra_get_reachable(void);
 int ra_get_retransmit(void);
 
+void notify_state_change(const char *status, int delay, bool resume);
+
 int script_init(const char *path, const char *ifname);
 ssize_t script_unhexlify(uint8_t *dst, size_t len, const char *src);
+void script_hexlify(char *dst, const uint8_t *src, size_t len);
 void script_call(const char *status, int delay, bool resume);
 
 bool odhcp6c_signal_process(void);

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -152,6 +152,32 @@ enum dhcpv6_msg {
 	_DHCPV6_MSG_MAX
 };
 
+enum dhcpv6_state {
+	DHCPV6_INIT,
+  	DHCPV6_SOLICIT,
+	DHCPV6_SOLICIT_PROCESSING,     	
+	DHCPV6_ADVERT,
+   	DHCPV6_REQUEST,  	
+	DHCPV6_REQUEST_PROCESSING,
+	DHCPV6_REPLY,		
+   	DHCPV6_BOUND,
+	DHCPV6_BOUND_PROCESSING,
+	DHCPV6_BOUND_REPLY,
+	DHCPV6_RECONF, 
+	DHCPV6_RECONF_PROCESSING,
+	DHCPV6_RECONF_REPLY, 
+	DHCPV6_RENEW, 
+	DHCPV6_RENEW_PROCESSING,
+	DHCPV6_RENEW_REPLY,
+	DHCPV6_REBIND,
+	DHCPV6_REBIND_PROCESSING,
+	DHCPV6_REBIND_REPLY,
+	DHCPV6_INFO,
+	DHCPV6_INFO_PROCESSING,
+	DHCPV6_INFO_REPLY,
+	DHCPV6_EXIT  		
+};
+
 enum dhcpv6_status {
 	DHCPV6_Success = 0,
 	DHCPV6_UnspecFail = 1,
@@ -191,6 +217,7 @@ struct dhcpv6_retx {
 	uint64_t round_start;
 	uint64_t round_end;
 	int reply_ret;
+	uint64_t delay_msec;
 };
 
 // DHCPv6 Protocol Headers
@@ -404,11 +431,16 @@ struct odhcp6c_opt {
 
 int init_dhcpv6(const char *ifname, unsigned int client_options, int sk_prio, int sol_timeout, unsigned int dscp);
 int dhcpv6_set_ia_mode(enum odhcp6c_ia_mode na, enum odhcp6c_ia_mode pd, bool stateful_only);
-int dhcpv6_request(enum dhcpv6_msg type);
-int dhcpv6_poll_reconfigure(void);
 int dhcpv6_promote_server_cand(void);
 int dhcpv6_send_request(enum dhcpv6_msg type);
 int dhcpv6_receive_response(enum dhcpv6_msg type);
+enum dhcpv6_state dhcpv6_get_state(void);
+void dhcpv6_set_state(enum dhcpv6_state state);
+int dhcpv6_get_socket(void);
+int dhcpv6_state_processing(enum dhcpv6_msg type);
+int dhcpv6_get_state_timeout(void);
+void dhcpv6_set_state_timeout(int timeout);
+void dhcpv6_reset_state_timeout(void);
 
 int init_rtnetlink(void);
 int set_rtnetlink_addr(int ifindex, const struct in6_addr *addr,

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -441,6 +441,7 @@ int dhcpv6_state_processing(enum dhcpv6_msg type);
 int dhcpv6_get_state_timeout(void);
 void dhcpv6_set_state_timeout(int timeout);
 void dhcpv6_reset_state_timeout(void);
+const char *dhcpv6_state_to_str(enum dhcpv6_state state);
 
 int init_rtnetlink(void);
 int set_rtnetlink_addr(int ifindex, const struct in6_addr *addr,

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -393,7 +393,7 @@ struct odhcp6c_opt {
 	const char *str;
 };
 
-int init_dhcpv6(const char *ifname, unsigned int client_options, int sk_prio, int sol_timeout);
+int init_dhcpv6(const char *ifname, unsigned int client_options, int sk_prio, int sol_timeout, unsigned int dscp);
 int dhcpv6_set_ia_mode(enum odhcp6c_ia_mode na, enum odhcp6c_ia_mode pd, bool stateful_only);
 int dhcpv6_request(enum dhcpv6_msg type);
 int dhcpv6_poll_reconfigure(void);

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -175,7 +175,8 @@ enum dhcpv6_state {
 	DHCPV6_INFO,
 	DHCPV6_INFO_PROCESSING,
 	DHCPV6_INFO_REPLY,
-	DHCPV6_EXIT  		
+	DHCPV6_EXIT,
+	DHCPV6_RESET,
 };
 
 enum dhcpv6_status {
@@ -470,6 +471,19 @@ int ra_get_reachable(void);
 int ra_get_retransmit(void);
 
 void notify_state_change(const char *status, int delay, bool resume);
+
+void config_set_release(bool enable);
+bool config_set_dscp(unsigned int value);
+bool config_set_solicit_timeout(unsigned int timeout);
+bool config_set_sk_priority(unsigned int value);
+void config_set_client_options(enum dhcpv6_config option, bool enable);
+bool config_set_request_addresses(char* mode);
+bool config_set_request_prefix(unsigned int length, unsigned int id);
+void config_set_stateful_only(bool enable);
+void config_clear_requested_options(void);
+bool config_add_requested_options(unsigned int option);
+void config_clear_send_options(void);
+bool config_add_send_options(char* option);
 
 int script_init(const char *path, const char *ifname);
 ssize_t script_unhexlify(uint8_t *dst, size_t len, const char *src);

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -477,13 +477,13 @@ bool config_set_dscp(unsigned int value);
 bool config_set_solicit_timeout(unsigned int timeout);
 bool config_set_sk_priority(unsigned int value);
 void config_set_client_options(enum dhcpv6_config option, bool enable);
-bool config_set_request_addresses(char* mode);
+bool config_set_request_addresses(char *mode);
 bool config_set_request_prefix(unsigned int length, unsigned int id);
 void config_set_stateful_only(bool enable);
 void config_clear_requested_options(void);
 bool config_add_requested_options(unsigned int option);
 void config_clear_send_options(void);
-bool config_add_send_options(char* option);
+bool config_add_send_options(char *option);
 
 int script_init(const char *path, const char *ifname);
 ssize_t script_unhexlify(uint8_t *dst, size_t len, const char *src);
@@ -512,3 +512,4 @@ bool odhcp6c_update_entry(enum odhcp6c_state state, struct odhcp6c_entry *new,
 void odhcp6c_expire(bool expire_ia_pd);
 uint32_t odhcp6c_elapsed(void);
 struct odhcp6c_opt *odhcp6c_find_opt(const uint16_t code);
+struct odhcp6c_opt *odhcp6c_find_opt_by_name(const char *name);

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -323,7 +323,22 @@ struct dhcpv6_server_cand {
 	size_t ia_pd_len;
 };
 
-
+struct dhcpv6_stats {
+	uint64_t solicit;
+	uint64_t advertise;
+	uint64_t request;
+	uint64_t confirm;
+	uint64_t renew;
+	uint64_t rebind;
+	uint64_t reply;
+	uint64_t release;
+	uint64_t decline;
+	uint64_t reconfigure;
+	uint64_t information_request;
+	uint64_t discarded_packets;
+	uint64_t transmit_failures;
+};
+	
 enum odhcp6c_state {
 	STATE_CLIENT_ID,
 	STATE_SERVER_ID,
@@ -437,6 +452,8 @@ int dhcpv6_receive_response(enum dhcpv6_msg type);
 enum dhcpv6_state dhcpv6_get_state(void);
 void dhcpv6_set_state(enum dhcpv6_state state);
 int dhcpv6_get_socket(void);
+struct dhcpv6_stats dhcpv6_get_stats(void);
+void dhcpv6_reset_stats(void);
 int dhcpv6_state_processing(enum dhcpv6_msg type);
 int dhcpv6_get_state_timeout(void);
 void dhcpv6_set_state_timeout(int timeout);

--- a/src/odhcp6c.h
+++ b/src/odhcp6c.h
@@ -182,6 +182,15 @@ struct dhcpv6_retx {
 	char name[8];
 	reply_handler *handler_reply;
 	int(*handler_finish)(void);
+	bool is_retransmit;
+	uint64_t timeout;
+	uint8_t rc;
+	uint64_t start;
+	uint8_t tr_id[3];
+	int64_t rto;
+	uint64_t round_start;
+	uint64_t round_end;
+	int reply_ret;
 };
 
 // DHCPv6 Protocol Headers
@@ -398,6 +407,8 @@ int dhcpv6_set_ia_mode(enum odhcp6c_ia_mode na, enum odhcp6c_ia_mode pd, bool st
 int dhcpv6_request(enum dhcpv6_msg type);
 int dhcpv6_poll_reconfigure(void);
 int dhcpv6_promote_server_cand(void);
+int dhcpv6_send_request(enum dhcpv6_msg type);
+int dhcpv6_receive_response(enum dhcpv6_msg type);
 
 int init_rtnetlink(void);
 int set_rtnetlink_addr(int ifindex, const struct in6_addr *addr,

--- a/src/script.c
+++ b/src/script.c
@@ -84,7 +84,7 @@ ssize_t script_unhexlify(uint8_t *dst, size_t len, const char *src)
 	return c;
 }
 
-static void script_hexlify(char *dst, const uint8_t *src, size_t len)
+void script_hexlify(char *dst, const uint8_t *src, size_t len)
 {
 	for (size_t i = 0; i < len; ++i) {
 		*dst++ = hexdigits[src[i] >> 4];

--- a/src/script.c
+++ b/src/script.c
@@ -171,7 +171,7 @@ static void entry_to_env(const char *name, const void *data, size_t len, enum en
 	size_t buf_len = strlen(name);
 	const struct odhcp6c_entry *e = data;
 	// Worst case: ENTRY_PREFIX with iaid != 1 and exclusion
-	const size_t max_entry_len = (INET6_ADDRSTRLEN-1 + 5 + 22 + 15 + 10 +
+	const size_t max_entry_len = (INET6_ADDRSTRLEN-1 + 5 + 44 + 15 + 10 +
 				      INET6_ADDRSTRLEN-1 + 11 + 1);
 	char *buf = realloc(NULL, buf_len + 2 + (len / sizeof(*e)) * max_entry_len);
 
@@ -205,7 +205,7 @@ static void entry_to_env(const char *name, const void *data, size_t len, enum en
 				snprintf(&buf[buf_len], 23, ",%u,%u", e[i].valid, e[i].priority);
 				buf_len += strlen(&buf[buf_len]);
 			} else {
-				snprintf(&buf[buf_len], 23, ",%u,%u", e[i].preferred, e[i].valid);
+				snprintf(&buf[buf_len], 45, ",%u,%u,%u,%u", e[i].preferred, e[i].valid, e[i].t1, e[i].t2);
 				buf_len += strlen(&buf[buf_len]);
 			}
 

--- a/src/script.c
+++ b/src/script.c
@@ -402,6 +402,9 @@ void script_call(const char *status, int delay, bool resume)
 	time_t now = odhcp6c_get_milli_time() / 1000;
 	bool running_script = false;
 
+	if (!argv[0])
+		return;
+
 	if (running) {
 		time_t diff = now - started;
 

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -138,6 +138,10 @@ static int ubus_handle_reset_stats(struct ubus_context *ctx, struct ubus_object 
 		struct ubus_request_data *req, const char *method, struct blob_attr *msg);
 static int ubus_handle_reconfigure_dhcp(struct ubus_context *ctx, struct ubus_object *obj,
 		struct ubus_request_data *req, const char *method, struct blob_attr *msg);
+static int ubus_handle_renew(struct ubus_context *ctx, struct ubus_object *obj,
+		struct ubus_request_data *req, const char *method, struct blob_attr *msg);
+static int ubus_handle_release(struct ubus_context *ctx, struct ubus_object *obj,
+		struct ubus_request_data *req, const char *method, struct blob_attr *msg);
 
 static const struct blobmsg_policy reconfigure_dhcp_policy[RECONFIGURE_DHCP_ATTR_MAX] = {
 	[RECONFIGURE_DHCP_ATTR_DSCP] = { .name = "dscp", .type = BLOBMSG_TYPE_INT32},
@@ -170,6 +174,8 @@ static struct ubus_method odhcp6c_object_methods[] = {
 	UBUS_METHOD_NOARG("get_statistics", ubus_handle_get_stats),
 	UBUS_METHOD_NOARG("reset_statistics", ubus_handle_reset_stats),
 	UBUS_METHOD("reconfigure_dhcp", ubus_handle_reconfigure_dhcp, reconfigure_dhcp_policy),
+	UBUS_METHOD_NOARG("renew", ubus_handle_renew),
+	UBUS_METHOD_NOARG("release", ubus_handle_release),
 };
 
 static struct ubus_object_type odhcp6c_object_type = 
@@ -904,6 +910,22 @@ static int ubus_handle_reconfigure_dhcp(_unused struct ubus_context *ctx, _unuse
 		raise(SIGUSR2);
 
 	return valid_args ? UBUS_STATUS_OK : UBUS_STATUS_INVALID_ARGUMENT;
+}
+
+static int ubus_handle_renew(_unused struct ubus_context *ctx, _unused struct ubus_object *obj,
+		_unused struct ubus_request_data *req, _unused const char *method,
+		_unused struct blob_attr *msg)
+{
+	raise(SIGUSR1);
+	return UBUS_STATUS_OK;
+}
+
+static int ubus_handle_release(_unused struct ubus_context *ctx, _unused struct ubus_object *obj,
+		_unused struct ubus_request_data *req, _unused const char *method,
+		_unused struct blob_attr *msg)
+{
+	raise(SIGUSR2);
+	return UBUS_STATUS_OK;
 }
 
 int ubus_dhcp_event(const char *status)

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -1,0 +1,140 @@
+/****************************************************************************
+**
+** SPDX-License-Identifier: BSD-2-Clause-Patent
+**
+** SPDX-FileCopyrightText: Copyright (c) 2024 SoftAtHome
+**
+** Redistribution and use in source and binary forms, with or
+** without modification, are permitted provided that the following
+** conditions are met:
+**
+** 1. Redistributions of source code must retain the above copyright
+** notice, this list of conditions and the following disclaimer.
+**
+** 2. Redistributions in binary form must reproduce the above
+** copyright notice, this list of conditions and the following
+** disclaimer in the documentation and/or other materials provided
+** with the distribution.
+**
+** Subject to the terms and conditions of this license, each
+** copyright holder and contributor hereby grants to those receiving
+** rights under this license a perpetual, worldwide, non-exclusive,
+** no-charge, royalty-free, irrevocable (except for failure to
+** satisfy the conditions of this license) patent license to make,
+** have made, use, offer to sell, sell, import, and otherwise
+** transfer this software, where such license applies only to those
+** patent claims, already acquired or hereafter acquired, licensable
+** by such copyright holder or contributor that are necessarily
+** infringed by:
+**
+** (a) their Contribution(s) (the licensed copyrights of copyright
+** holders and non-copyrightable additions of contributors, in
+** source or binary form) alone; or
+**
+** (b) combination of their Contribution(s) with the work of
+** authorship to which such Contribution(s) was added by such
+** copyright holder or contributor, if, at the time the Contribution
+** is added, such addition causes such combination to be necessarily
+** infringed. The patent license shall not apply to any other
+** combinations which include the Contribution.
+**
+** Except as expressly stated above, no rights or licenses from any
+** copyright holder or contributor is granted under this license,
+** whether expressly, by implication, estoppel or otherwise.
+**
+** DISCLAIMER
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+** CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+** MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+** CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+** USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+** AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+** LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+** ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+** POSSIBILITY OF SUCH DAMAGE.
+**
+****************************************************************************/
+#include "odhcp6c.h"
+
+
+#include <sys/types.h>
+#include <arpa/inet.h>
+#include <resolv.h>
+#include <stdio.h>
+#include <syslog.h>
+#include <inttypes.h>
+#include <libubus.h>
+#include <libubox/blobmsg.h>
+
+#include "ubus.h"
+
+struct ubus_context *ubus = NULL;
+static char ubus_name[24];
+
+static int ubus_handle_get_state(struct ubus_context *ctx, struct ubus_object *obj,
+		struct ubus_request_data *req, const char *method, struct blob_attr *msg);
+
+static struct ubus_object_type odhcp6c_object_type = {
+	.name = "odhcp6c"
+};
+
+static struct ubus_object odhcp6c_object = {
+	.name = NULL,
+	.type = &odhcp6c_object_type,
+	.methods = odhcp6c_object_methods,
+	.n_methods = ARRAY_SIZE(odhcp6c_object_methods),
+};
+
+static void ubus_disconnect_cb(struct ubus_context *ubus)
+{
+	int ret;
+
+	ret = ubus_reconnect(ubus, NULL);
+	if (ret) {
+		syslog(LOG_ERR, "Cannot reconnect to ubus: %s", ubus_strerror(ret));
+		ubus_destroy(ubus);
+	}
+}
+
+char *ubus_init(const char* interface) 
+{
+	int ret = 0;
+
+ 	if (!(ubus = ubus_connect(NULL)))
+		return NULL;
+
+	snprintf(ubus_name, 24, "odhcp6c.%s", interface);
+	odhcp6c_object.name = ubus_name;
+	
+	ret = ubus_add_object(ubus, &odhcp6c_object);
+	if (ret) {
+		ubus_destroy(ubus);
+		return (char *)ubus_strerror(ret);
+	}
+
+	ubus->connection_lost = ubus_disconnect_cb;
+	return NULL;
+}
+
+struct ubus_context *ubus_get_ctx(void)
+{
+	return ubus;
+}
+
+void ubus_destroy(struct ubus_context *ubus)
+{
+	syslog(LOG_NOTICE, "Disconnecting from ubus");
+	
+	if (ubus != NULL)
+		ubus_free(ubus);
+	ubus = NULL;
+
+	/* Forces re-initialization when we're reusing the same definitions later on. */
+	odhcp6c_object.id = 0;
+	odhcp6c_object.id = 0;
+}

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -123,6 +123,8 @@ enum {
 	RECONFIGURE_DHCP_ATTR_IRT_DEFAULT,
 	RECONFIGURE_DHCP_ATTR_IRT_MIN,
 	RECONFIGURE_DHCP_ATTR_RAND_FACTOR,
+	RECONFIGURE_DHCP_ATTR_AUTH_PROTO,
+	RECONFIGURE_DHCP_ATTR_AUTH_TOKEN,
 	RECONFIGURE_DHCP_ATTR_MAX,
 };
 
@@ -167,6 +169,8 @@ static const struct blobmsg_policy reconfigure_dhcp_policy[RECONFIGURE_DHCP_ATTR
 	[RECONFIGURE_DHCP_ATTR_IRT_DEFAULT] = { .name = "irt_default", .type = BLOBMSG_TYPE_INT32},
 	[RECONFIGURE_DHCP_ATTR_IRT_MIN] = { .name = "irt_min", .type = BLOBMSG_TYPE_INT32},
 	[RECONFIGURE_DHCP_ATTR_RAND_FACTOR] = { .name = "rand_factor", .type = BLOBMSG_TYPE_INT32},
+	[RECONFIGURE_DHCP_ATTR_AUTH_PROTO] = { .name = "auth_protocol", .type = BLOBMSG_TYPE_STRING},
+	[RECONFIGURE_DHCP_ATTR_AUTH_TOKEN] = { .name = "auth_token", .type = BLOBMSG_TYPE_STRING},
 };
 
 static struct ubus_method odhcp6c_object_methods[] = {
@@ -900,6 +904,26 @@ static int ubus_handle_reconfigure_dhcp(_unused struct ubus_context *ctx, _unuse
 		value = blobmsg_get_u32(cur);
 
 		if (!config_set_rand_factor(value))
+			return UBUS_STATUS_INVALID_ARGUMENT;
+
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_AUTH_PROTO])) {
+		string = blobmsg_get_string(cur);
+
+		if (string == NULL || !config_set_auth_protocol(string))
+			return UBUS_STATUS_INVALID_ARGUMENT;
+
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_AUTH_TOKEN])) {
+		string = blobmsg_get_string(cur);
+
+		if (string == NULL || !config_set_auth_token(string))
 			return UBUS_STATUS_INVALID_ARGUMENT;
 
 		need_reinit = true;

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -73,7 +73,33 @@
 
 #include "ubus.h"
 
+#define CHECK(stmt) \
+	do { \
+		int ret = (stmt); \
+		if (ret != UBUS_STATUS_OK) \
+		{ \
+			syslog(LOG_ERR, "%s failed: %s (%d)", #stmt, ubus_strerror(ret), ret); \
+			return ret; \
+		} \
+	} while (0)
+
+#define CHECK_ALLOC(buf) \
+	do { \
+		if (buf == NULL) \
+		{ \
+			return UBUS_STATUS_NO_MEMORY; \
+		} \
+	} while (0)
+
+enum entry_type {
+	ENTRY_ADDRESS,
+	ENTRY_HOST,
+	ENTRY_ROUTE,
+	ENTRY_PREFIX
+};
+
 struct ubus_context *ubus = NULL;
+static struct blob_buf b;
 static char ubus_name[24];
 
 static int ubus_handle_get_state(struct ubus_context *ctx, struct ubus_object *obj,
@@ -137,4 +163,369 @@ void ubus_destroy(struct ubus_context *ubus)
 	/* Forces re-initialization when we're reusing the same definitions later on. */
 	odhcp6c_object.id = 0;
 	odhcp6c_object.id = 0;
+}
+
+static int ipv6_to_blob(const char *name,
+		const struct in6_addr *addr, size_t cnt)
+{
+	void *arr = blobmsg_open_array(&b, name);
+	
+	for (size_t i = 0; i < cnt; ++i) {
+		char *buf = blobmsg_alloc_string_buffer(&b, NULL, INET6_ADDRSTRLEN);
+		CHECK_ALLOC(buf);
+		inet_ntop(AF_INET6, &addr[i], buf, INET6_ADDRSTRLEN);
+		blobmsg_add_string_buffer(&b);
+	}
+
+	blobmsg_close_array(&b, arr);
+	return UBUS_STATUS_OK;
+}
+
+static int fqdn_to_blob(const char *name, const uint8_t *fqdn, size_t len)
+{
+	size_t buf_size = len > 255 ? 256 : (len + 1);
+	const uint8_t *fqdn_end = fqdn + len;
+	char *buf = NULL;
+
+	void *arr = blobmsg_open_array(&b, name);
+
+	while (fqdn < fqdn_end) {
+		buf = blobmsg_alloc_string_buffer(&b, name, buf_size);
+		CHECK_ALLOC(buf);
+		int l = dn_expand(fqdn, fqdn_end, fqdn, buf, buf_size);
+		if (l < 1) {
+			buf[0] = '\0';
+			blobmsg_add_string_buffer(&b);
+			break;
+		}
+		buf[l] = '\0';
+		blobmsg_add_string_buffer(&b);
+		fqdn += l;
+	}
+
+	blobmsg_close_array(&b, arr);
+	return UBUS_STATUS_OK;
+}
+
+static int bin_to_blob(uint8_t *opts, size_t len)
+{
+	uint8_t *oend = opts + len, *odata;
+	uint16_t otype, olen;
+
+	dhcpv6_for_each_option(opts, oend, otype, olen, odata) {
+		char name[14];
+		char *buf;
+
+		snprintf(name, 14, "OPTION_%hu", otype);
+		buf = blobmsg_alloc_string_buffer(&b, name, olen * 2);
+		CHECK_ALLOC(buf);
+		script_hexlify(buf, odata, olen);
+		blobmsg_add_string_buffer(&b);
+	}
+	return UBUS_STATUS_OK;
+}
+
+static int entry_to_blob(const char *name, const void *data, size_t len, enum entry_type type)
+{
+	const struct odhcp6c_entry *e = data;
+
+	void *arr = blobmsg_open_array(&b, name);
+
+	for (size_t i = 0; i < len / sizeof(*e); ++i) {
+		void *entry = blobmsg_open_table(&b, name);
+
+		/*
+		 * The only invalid entries allowed to be passed to the script are prefix entries.
+		 * This will allow immediate removal of the old ipv6-prefix-assignment that might
+		 * otherwise be kept for up to 2 hours (see L-13 requirement of RFC 7084).
+		 */
+		if (!e[i].valid && type != ENTRY_PREFIX)
+			continue;
+
+		char *buf = blobmsg_alloc_string_buffer(&b, "target", INET6_ADDRSTRLEN);
+		CHECK_ALLOC(buf);
+		inet_ntop(AF_INET6, &e[i].target, buf, INET6_ADDRSTRLEN);
+		blobmsg_add_string_buffer(&b);
+
+		if (type != ENTRY_HOST) {
+			blobmsg_add_u8(&b, "length", e[i].length);
+			if (type == ENTRY_ROUTE) {
+				if (!IN6_IS_ADDR_UNSPECIFIED(&e[i].router)) {
+					buf = blobmsg_alloc_string_buffer(&b, "router", INET6_ADDRSTRLEN);
+					CHECK_ALLOC(buf);
+					inet_ntop(AF_INET6, &e[i].router, buf, INET6_ADDRSTRLEN);
+					blobmsg_add_string_buffer(&b);
+				}
+
+				blobmsg_add_u32(&b, "valid", e[i].valid);
+				blobmsg_add_u16(&b, "priority", e[i].priority);
+			} else {
+				blobmsg_add_u32(&b, "valid", e[i].valid);
+				blobmsg_add_u32(&b, "preferred", e[i].preferred);
+				blobmsg_add_u32(&b, "t1", e[i].t1);
+				blobmsg_add_u32(&b, "t2", e[i].t2);
+			}
+
+			if (type == ENTRY_PREFIX && ntohl(e[i].iaid) != 1) {
+				blobmsg_add_u32(&b, "iaid", ntohl(e[i].iaid));
+			}
+
+			if (type == ENTRY_PREFIX && e[i].priority) {
+				// priority and router are abused for prefix exclusion
+				buf = blobmsg_alloc_string_buffer(&b, "excluded", INET6_ADDRSTRLEN);
+				CHECK_ALLOC(buf);
+				inet_ntop(AF_INET6, &e[i].router, buf, INET6_ADDRSTRLEN);
+				blobmsg_add_string_buffer(&b);
+				blobmsg_add_u16(&b, "excluded_length", e[i].priority);
+			}
+		}
+
+		blobmsg_close_table(&b, entry);
+	}
+
+	blobmsg_close_array(&b, arr);
+	return UBUS_STATUS_OK;
+}
+
+static int search_to_blob(const char *name, const uint8_t *start, size_t len)
+{
+	void *arr = blobmsg_open_array(&b, name);
+	char *buf = NULL;
+
+	for (struct odhcp6c_entry *e = (struct odhcp6c_entry*)start;
+				(uint8_t*)e < &start[len] &&
+				(uint8_t*)odhcp6c_next_entry(e) <= &start[len];
+				e = odhcp6c_next_entry(e)) {
+		if (!e->valid)
+			continue;
+		
+		buf = blobmsg_alloc_string_buffer(&b, NULL, e->auxlen+1);
+		CHECK_ALLOC(buf);
+		buf = mempcpy(buf, e->auxtarget, e->auxlen);
+		*buf = '\0';
+		blobmsg_add_string_buffer(&b);
+	}
+
+	blobmsg_close_array(&b, arr);
+	return UBUS_STATUS_OK;
+}
+
+static int s46_to_blob_portparams(const uint8_t *data, size_t len)
+{
+	uint8_t *odata;
+	uint16_t otype, olen;
+
+	dhcpv6_for_each_option(data, &data[len], otype, olen, odata) {
+		if (otype == DHCPV6_OPT_S46_PORTPARAMS &&
+				olen == sizeof(struct dhcpv6_s46_portparams)) {
+			struct dhcpv6_s46_portparams *params = (void*)odata;
+			blobmsg_add_u8(&b, "offset", params->offset);
+			blobmsg_add_u8(&b, "psidlen", params->psid_len);
+			blobmsg_add_u16(&b, "psid", ntohs(params->psid));
+		}
+	}
+	return UBUS_STATUS_OK;
+}
+
+static int s46_to_blob(enum odhcp6c_state state, const uint8_t *data, size_t len)
+{
+	const char *name = (state == STATE_S46_MAPE) ? "MAPE" :
+			(state == STATE_S46_MAPT) ? "MAPT" : "LW4O6";
+
+	if (len == 0)
+		return UBUS_STATUS_OK;
+
+	char *buf = NULL;
+	void *arr = blobmsg_open_array(&b, name);
+
+	const char *type = (state == STATE_S46_MAPE) ? "map-e" :
+			(state == STATE_S46_MAPT) ? "map-t" : "lw4o6";
+
+	uint8_t *odata;
+	uint16_t otype, olen;
+
+	dhcpv6_for_each_option(data, &data[len], otype, olen, odata) {
+		struct dhcpv6_s46_rule *rule = (struct dhcpv6_s46_rule*)odata;
+		struct dhcpv6_s46_v4v6bind *bind = (struct dhcpv6_s46_v4v6bind*)odata;
+
+		void *option = blobmsg_open_table(&b, NULL);
+
+		if (state != STATE_S46_LW && otype == DHCPV6_OPT_S46_RULE &&
+				olen >= sizeof(struct dhcpv6_s46_rule)) {
+			struct in6_addr in6 = IN6ADDR_ANY_INIT;
+
+			size_t prefix6len = rule->prefix6_len;
+			prefix6len = (prefix6len % 8 == 0) ? prefix6len / 8 : prefix6len / 8 + 1;
+
+			if (prefix6len > sizeof(in6) ||
+				olen < sizeof(struct dhcpv6_s46_rule) + prefix6len)
+				continue;
+
+			memcpy(&in6, rule->ipv6_prefix, prefix6len);
+
+			buf = blobmsg_alloc_string_buffer(&b, "ipv4prefix", INET_ADDRSTRLEN);
+			CHECK_ALLOC(buf);
+			inet_ntop(AF_INET, &rule->ipv4_prefix, buf, INET_ADDRSTRLEN);
+			blobmsg_add_string_buffer(&b);
+
+			buf = blobmsg_alloc_string_buffer(&b, "ipv6prefix", INET6_ADDRSTRLEN);
+			CHECK_ALLOC(buf);
+			inet_ntop(AF_INET6, &in6, buf, INET6_ADDRSTRLEN);
+			blobmsg_add_string_buffer(&b);
+
+			blobmsg_add_u8(&b, "fmr", rule->flags);
+			blobmsg_add_string(&b, "type", type);
+			blobmsg_add_u8(&b, "ealen", rule->ea_len);
+			blobmsg_add_u8(&b, "prefix4len", rule->prefix4_len);
+			blobmsg_add_u8(&b, "prefix6len", rule->prefix6_len);
+
+			s46_to_blob_portparams(&rule->ipv6_prefix[prefix6len],
+					olen - sizeof(*rule) - prefix6len);
+
+			dhcpv6_for_each_option(data, &data[len], otype, olen, odata) {
+				if (state != STATE_S46_MAPT && otype == DHCPV6_OPT_S46_BR &&
+						olen == sizeof(struct in6_addr)) {
+					buf = blobmsg_alloc_string_buffer(&b, "br", INET6_ADDRSTRLEN);
+					CHECK_ALLOC(buf);
+					inet_ntop(AF_INET6, odata, buf, INET6_ADDRSTRLEN);
+					blobmsg_add_string_buffer(&b);
+				} else if (state == STATE_S46_MAPT && otype == DHCPV6_OPT_S46_DMR &&
+						olen >= sizeof(struct dhcpv6_s46_dmr)) {
+					struct dhcpv6_s46_dmr *dmr = (struct dhcpv6_s46_dmr*)odata;
+					memset(&in6, 0, sizeof(in6));
+					size_t prefix6len = dmr->dmr_prefix6_len;
+					prefix6len = (prefix6len % 8 == 0) ? prefix6len / 8 : prefix6len / 8 + 1;
+
+					if (prefix6len > sizeof(in6) ||
+						olen < sizeof(struct dhcpv6_s46_dmr) + prefix6len)
+						continue;
+
+					buf = blobmsg_alloc_string_buffer(&b, "dmr", INET6_ADDRSTRLEN);
+					CHECK_ALLOC(buf);
+					inet_ntop(AF_INET6, &in6, buf, INET6_ADDRSTRLEN);
+					blobmsg_add_string_buffer(&b);
+					blobmsg_add_u8(&b, "dmrprefix6len", dmr->dmr_prefix6_len);
+				}
+			}
+		} else if (state == STATE_S46_LW && otype == DHCPV6_OPT_S46_V4V6BIND &&
+				olen >= sizeof(struct dhcpv6_s46_v4v6bind)) {
+			struct in6_addr in6 = IN6ADDR_ANY_INIT;
+
+			size_t prefix6len = bind->bindprefix6_len;
+			prefix6len = (prefix6len % 8 == 0) ? prefix6len / 8 : prefix6len / 8 + 1;
+
+			if (prefix6len > sizeof(in6) ||
+				olen < sizeof(struct dhcpv6_s46_v4v6bind) + prefix6len)
+				continue;
+
+			memcpy(&in6, bind->bind_ipv6_prefix, prefix6len);
+
+			buf = blobmsg_alloc_string_buffer(&b, "ipv4prefix", INET_ADDRSTRLEN);
+			CHECK_ALLOC(buf);
+			inet_ntop(AF_INET, &bind->ipv4_address, buf, INET_ADDRSTRLEN);
+			blobmsg_add_string_buffer(&b);
+
+			buf = blobmsg_alloc_string_buffer(&b, "ipv6prefix", INET6_ADDRSTRLEN);
+			CHECK_ALLOC(buf);
+			inet_ntop(AF_INET6, &in6, buf, INET6_ADDRSTRLEN);
+			blobmsg_add_string_buffer(&b);
+
+			blobmsg_add_string(&b, "type", type);
+			blobmsg_add_u8(&b, "prefix4len", 32);
+			blobmsg_add_u8(&b, "prefix6len", bind->bindprefix6_len);
+
+			s46_to_blob_portparams(&bind->bind_ipv6_prefix[prefix6len],
+					olen - sizeof(*bind) - prefix6len);
+
+			dhcpv6_for_each_option(data, &data[len], otype, olen, odata) {
+				if (otype == DHCPV6_OPT_S46_BR && olen == sizeof(struct in6_addr)) {
+					buf = blobmsg_alloc_string_buffer(&b, "br", INET6_ADDRSTRLEN);
+					CHECK_ALLOC(buf);
+					inet_ntop(AF_INET6, odata, buf, INET6_ADDRSTRLEN);
+					blobmsg_add_string_buffer(&b);
+				}
+			}
+		}
+		blobmsg_close_table(&b, option);
+	}
+
+	blobmsg_close_array(&b, arr);
+	return UBUS_STATUS_OK;
+}
+
+int ubus_dhcp_event(const char* status)
+{
+	if (!ubus || !odhcp6c_object.has_subscribers)
+    	return UBUS_STATUS_UNKNOWN_ERROR;
+
+	char *buf = NULL;
+
+	size_t dns_len, search_len, custom_len, sntp_ip_len, ntp_ip_len, ntp_dns_len;
+	size_t sip_ip_len, sip_fqdn_len, aftr_name_len, cer_len, addr_len;
+	size_t s46_mapt_len, s46_mape_len, s46_lw_len, passthru_len;
+	struct in6_addr *addr = odhcp6c_get_state(STATE_SERVER_ADDR, &addr_len);
+	struct in6_addr *dns = odhcp6c_get_state(STATE_DNS, &dns_len);
+	uint8_t *search = odhcp6c_get_state(STATE_SEARCH, &search_len);
+	uint8_t *custom = odhcp6c_get_state(STATE_CUSTOM_OPTS, &custom_len);
+	struct in6_addr *sntp = odhcp6c_get_state(STATE_SNTP_IP, &sntp_ip_len);
+	struct in6_addr *ntp = odhcp6c_get_state(STATE_NTP_IP, &ntp_ip_len);
+	uint8_t *ntp_dns = odhcp6c_get_state(STATE_NTP_FQDN, &ntp_dns_len);
+	struct in6_addr *sip = odhcp6c_get_state(STATE_SIP_IP, &sip_ip_len);
+	uint8_t *sip_fqdn = odhcp6c_get_state(STATE_SIP_FQDN, &sip_fqdn_len);
+	uint8_t *aftr_name = odhcp6c_get_state(STATE_AFTR_NAME, &aftr_name_len);
+	struct in6_addr *cer = odhcp6c_get_state(STATE_CER, &cer_len);
+	uint8_t *s46_mapt = odhcp6c_get_state(STATE_S46_MAPT, &s46_mapt_len);
+	uint8_t *s46_mape = odhcp6c_get_state(STATE_S46_MAPE, &s46_mape_len);
+	uint8_t *s46_lw = odhcp6c_get_state(STATE_S46_LW, &s46_lw_len);
+	uint8_t *passthru = odhcp6c_get_state(STATE_PASSTHRU, &passthru_len);
+
+	size_t prefix_len, address_len, ra_pref_len,
+		ra_route_len, ra_dns_len, ra_search_len;
+	uint8_t *prefix = odhcp6c_get_state(STATE_IA_PD, &prefix_len);
+	uint8_t *address = odhcp6c_get_state(STATE_IA_NA, &address_len);
+	uint8_t *ra_pref = odhcp6c_get_state(STATE_RA_PREFIX, &ra_pref_len);
+	uint8_t *ra_route = odhcp6c_get_state(STATE_RA_ROUTE, &ra_route_len);
+	uint8_t *ra_dns = odhcp6c_get_state(STATE_RA_DNS, &ra_dns_len);
+	uint8_t *ra_search = odhcp6c_get_state(STATE_RA_SEARCH, &ra_search_len);
+
+ 	blob_buf_init(&b, BLOBMSG_TYPE_TABLE);
+
+	CHECK(ipv6_to_blob("SERVER", addr, addr_len / sizeof(*addr)));
+	CHECK(ipv6_to_blob("RDNSS", dns, dns_len / sizeof(*dns)));
+	CHECK(ipv6_to_blob("SNTP_IP", sntp, sntp_ip_len / sizeof(*sntp)));
+	CHECK(ipv6_to_blob("NTP_IP", ntp, ntp_ip_len / sizeof(*ntp)));
+	CHECK(fqdn_to_blob("NTP_FQDN", ntp_dns, ntp_dns_len));
+	CHECK(ipv6_to_blob("SIP_IP", sip, sip_ip_len / sizeof(*sip)));
+	CHECK(fqdn_to_blob("DOMAINS", search, search_len));
+	CHECK(fqdn_to_blob("SIP_DOMAIN", sip_fqdn, sip_fqdn_len));
+	CHECK(fqdn_to_blob("AFTR", aftr_name, aftr_name_len));
+	CHECK(ipv6_to_blob("CER", cer, cer_len / sizeof(*cer)));
+	CHECK(s46_to_blob(STATE_S46_MAPE, s46_mape, s46_mape_len));
+	CHECK(s46_to_blob(STATE_S46_MAPT, s46_mapt, s46_mapt_len));
+	CHECK(s46_to_blob(STATE_S46_LW, s46_lw, s46_lw_len));
+	CHECK(bin_to_blob(custom, custom_len));
+
+	if (odhcp6c_is_bound()) {
+		CHECK(entry_to_blob("PREFIXES", prefix, prefix_len, ENTRY_PREFIX));
+		CHECK(entry_to_blob("ADDRESSES", address, address_len, ENTRY_ADDRESS));
+	}
+
+	CHECK(entry_to_blob("RA_ADDRESSES", ra_pref, ra_pref_len, ENTRY_ADDRESS));
+	CHECK(entry_to_blob("RA_ROUTES", ra_route, ra_route_len, ENTRY_ROUTE));
+	CHECK(entry_to_blob("RA_DNS", ra_dns, ra_dns_len, ENTRY_HOST));
+	CHECK(search_to_blob("RA_DOMAINS", ra_search, ra_search_len));
+
+	blobmsg_add_u32(&b, "RA_HOPLIMIT", ra_get_hoplimit());
+	blobmsg_add_u32(&b, "RA_MTU", ra_get_mtu());
+	blobmsg_add_u32(&b, "RA_REACHABLE", ra_get_reachable());
+	blobmsg_add_u32(&b, "RA_RETRANSMIT", ra_get_retransmit());
+	
+	buf = blobmsg_alloc_string_buffer(&b, "PASSTHRU", passthru_len * 2);
+	CHECK_ALLOC(buf);
+	script_hexlify(buf, passthru, passthru_len);
+	blobmsg_add_string_buffer(&b);
+	CHECK(ubus_notify(ubus, &odhcp6c_object, status, b.head, -1));
+	blob_buf_free(&b);
+
+	return UBUS_STATUS_OK;
 }

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -98,6 +98,23 @@ enum entry_type {
 	ENTRY_PREFIX
 };
 
+enum {
+	RECONFIGURE_DHCP_ATTR_DSCP,
+	RECONFIGURE_DHCP_ATTR_RELEASE,
+	RECONFIGURE_DHCP_ATTR_SOL_TIMEOUT,
+	RECONFIGURE_DHCP_ATTR_SK_PRIORITY,
+	RECONFIGURE_DHCP_ATTR_OPT_REQUESTED,
+	RECONFIGURE_DHCP_ATTR_OPT_STRICT,
+	RECONFIGURE_DHCP_ATTR_OPT_RECONFIGURE,
+	RECONFIGURE_DHCP_ATTR_OPT_FQDN,
+	RECONFIGURE_DHCP_ATTR_OPT_UNICAST,
+	RECONFIGURE_DHCP_ATTR_OPT_SEND,
+	RECONFIGURE_DHCP_ATTR_REQ_ADDRESSES,
+	RECONFIGURE_DHCP_ATTR_REQ_PREFIXES,
+	RECONFIGURE_DHCP_ATTR_STATEFUL,
+	RECONFIGURE_DHCP_ATTR_MAX,
+};
+
 struct ubus_context *ubus = NULL;
 static struct blob_buf b;
 static char ubus_name[24];
@@ -108,11 +125,30 @@ static int ubus_handle_get_stats(struct ubus_context *ctx, struct ubus_object *o
 		struct ubus_request_data *req, const char *method, struct blob_attr *msg);
 static int ubus_handle_reset_stats(struct ubus_context *ctx, struct ubus_object *obj,
 		struct ubus_request_data *req, const char *method, struct blob_attr *msg);
+static int ubus_handle_reconfigure_dhcp(struct ubus_context *ctx, struct ubus_object *obj,
+		struct ubus_request_data *req, const char *method, struct blob_attr *msg);
+
+static const struct blobmsg_policy reconfigure_dhcp_policy[RECONFIGURE_DHCP_ATTR_MAX] = {
+	[RECONFIGURE_DHCP_ATTR_DSCP] = { .name = "dscp", .type = BLOBMSG_TYPE_INT32},
+	[RECONFIGURE_DHCP_ATTR_RELEASE] = { .name = "release", .type = BLOBMSG_TYPE_BOOL},
+	[RECONFIGURE_DHCP_ATTR_SOL_TIMEOUT] = { .name = "sol_timeout", .type = BLOBMSG_TYPE_INT32},
+	[RECONFIGURE_DHCP_ATTR_SK_PRIORITY] = { .name = "sk_prio", .type = BLOBMSG_TYPE_INT32},
+	[RECONFIGURE_DHCP_ATTR_OPT_REQUESTED] = { .name = "opt_requested", .type = BLOBMSG_TYPE_ARRAY},
+	[RECONFIGURE_DHCP_ATTR_OPT_STRICT] = { .name = "opt_strict", .type = BLOBMSG_TYPE_BOOL},
+	[RECONFIGURE_DHCP_ATTR_OPT_RECONFIGURE] = { .name = "opt_reconfigure", .type = BLOBMSG_TYPE_BOOL},
+	[RECONFIGURE_DHCP_ATTR_OPT_FQDN] = { .name = "opt_fqdn", .type = BLOBMSG_TYPE_BOOL},
+	[RECONFIGURE_DHCP_ATTR_OPT_UNICAST] = { .name = "opt_unicast", .type = BLOBMSG_TYPE_BOOL},
+	[RECONFIGURE_DHCP_ATTR_OPT_SEND] = { .name = "opt_send", .type = BLOBMSG_TYPE_ARRAY},
+	[RECONFIGURE_DHCP_ATTR_REQ_ADDRESSES] = { .name = "req_addresses", .type = BLOBMSG_TYPE_STRING},
+	[RECONFIGURE_DHCP_ATTR_REQ_PREFIXES] = { .name = "req_prefixes", .type = BLOBMSG_TYPE_INT32},
+	[RECONFIGURE_DHCP_ATTR_STATEFUL] = { .name = "stateful_only", .type = BLOBMSG_TYPE_BOOL},
+};
 
 static struct ubus_method odhcp6c_object_methods[] = {
 	UBUS_METHOD_NOARG("get_state", ubus_handle_get_state),
 	UBUS_METHOD_NOARG("get_statistics", ubus_handle_get_stats),
 	UBUS_METHOD_NOARG("reset_statistics", ubus_handle_reset_stats),
+	UBUS_METHOD("reconfigure_dhcp", ubus_handle_reconfigure_dhcp, reconfigure_dhcp_policy),
 };
 
 static struct ubus_object_type odhcp6c_object_type = 
@@ -581,6 +617,149 @@ static int ubus_handle_get_state(struct ubus_context *ctx, _unused struct ubus_o
 	blob_buf_free(&b);
 
 	return UBUS_STATUS_OK;
+}
+
+static int ubus_handle_reconfigure_dhcp(_unused struct ubus_context *ctx, _unused struct ubus_object *obj,
+		_unused struct ubus_request_data *req, _unused const char *method,
+		struct blob_attr *msg)
+{
+	const struct blobmsg_policy *policy = reconfigure_dhcp_policy;
+	struct blob_attr *tb[RECONFIGURE_DHCP_ATTR_MAX];
+	struct blob_attr *cur = NULL;
+	struct blob_attr *elem = NULL;
+	char *string = NULL;
+	uint32_t value = 0;
+	uint32_t index = 0;
+	bool enabled = false;
+	bool valid_args = false;
+	bool need_reinit = false;
+
+	if (blobmsg_parse(policy, RECONFIGURE_DHCP_ATTR_MAX, tb, blob_data(msg), blob_len(msg)))
+		return UBUS_STATUS_INVALID_ARGUMENT;
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_DSCP])) {
+		value = blobmsg_get_u32(cur);
+		if (!config_set_dscp(value))
+			return UBUS_STATUS_INVALID_ARGUMENT;
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_RELEASE])) {
+		enabled = blobmsg_get_bool(cur);
+		config_set_release(enabled);
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_SOL_TIMEOUT])) {
+		value = blobmsg_get_u32(cur);
+		if (!config_set_solicit_timeout(value))
+			return UBUS_STATUS_INVALID_ARGUMENT;
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_SK_PRIORITY])) {
+		value = blobmsg_get_u32(cur);
+		if (!config_set_sk_priority(value))
+			return UBUS_STATUS_INVALID_ARGUMENT;
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_OPT_REQUESTED])) {
+		if (blobmsg_type(cur) != BLOBMSG_TYPE_ARRAY || !blobmsg_check_attr(cur, false))
+			return UBUS_STATUS_INVALID_ARGUMENT;
+
+		config_clear_requested_options();
+
+		blobmsg_for_each_attr(elem, cur, index) {
+			if (blobmsg_type(elem) != BLOBMSG_TYPE_INT32)
+				return UBUS_STATUS_INVALID_ARGUMENT;
+
+			value = blobmsg_get_u32(elem);
+			if (!config_add_requested_options(value))
+				return UBUS_STATUS_INVALID_ARGUMENT;
+		}
+
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_OPT_STRICT])) {
+		enabled = blobmsg_get_bool(cur);
+		config_set_client_options(DHCPV6_STRICT_OPTIONS, enabled);
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_OPT_RECONFIGURE])) {
+		enabled = blobmsg_get_bool(cur);
+		config_set_client_options(DHCPV6_ACCEPT_RECONFIGURE, enabled);
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_OPT_FQDN])) {
+		enabled = blobmsg_get_bool(cur);
+		config_set_client_options(DHCPV6_CLIENT_FQDN, enabled);
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_OPT_UNICAST])) {
+		enabled = blobmsg_get_bool(cur);
+		config_set_client_options(DHCPV6_IGNORE_OPT_UNICAST, enabled);
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_OPT_SEND])) {
+		if (blobmsg_type(cur) != BLOBMSG_TYPE_ARRAY || !blobmsg_check_attr(cur, false))
+			return UBUS_STATUS_INVALID_ARGUMENT;
+
+		config_clear_send_options();
+
+		blobmsg_for_each_attr(elem, cur, index) {
+			string = blobmsg_get_string(elem);
+			if (string == NULL || !config_add_send_options(string))
+				return UBUS_STATUS_INVALID_ARGUMENT;
+		}
+
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_REQ_ADDRESSES])) {
+		string = blobmsg_get_string(cur);
+		if (string == NULL || !config_set_request_addresses(string))
+			return UBUS_STATUS_INVALID_ARGUMENT;
+
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_REQ_PREFIXES])) {
+		value = blobmsg_get_u32(cur);
+
+		if (!config_set_request_prefix(value, 1))
+			return UBUS_STATUS_INVALID_ARGUMENT;
+
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if ((cur = tb[RECONFIGURE_DHCP_ATTR_STATEFUL])) {
+		enabled = blobmsg_get_bool(cur);
+		config_set_stateful_only(enabled);
+		need_reinit = true;
+		valid_args = true;
+	}
+
+	if (need_reinit)
+		raise(SIGUSR2);
+
+	return valid_args ? UBUS_STATUS_OK : UBUS_STATUS_INVALID_ARGUMENT;
 }
 
 int ubus_dhcp_event(const char *status)

--- a/src/ubus.c
+++ b/src/ubus.c
@@ -104,9 +104,15 @@ static char ubus_name[24];
 
 static int ubus_handle_get_state(struct ubus_context *ctx, struct ubus_object *obj,
 		struct ubus_request_data *req, const char *method, struct blob_attr *msg);
+static int ubus_handle_get_stats(struct ubus_context *ctx, struct ubus_object *obj,
+		struct ubus_request_data *req, const char *method, struct blob_attr *msg);
+static int ubus_handle_reset_stats(struct ubus_context *ctx, struct ubus_object *obj,
+		struct ubus_request_data *req, const char *method, struct blob_attr *msg);
 
 static struct ubus_method odhcp6c_object_methods[] = {
 	UBUS_METHOD_NOARG("get_state", ubus_handle_get_state),
+	UBUS_METHOD_NOARG("get_statistics", ubus_handle_get_stats),
+	UBUS_METHOD_NOARG("reset_statistics", ubus_handle_reset_stats),
 };
 
 static struct ubus_object_type odhcp6c_object_type = 
@@ -528,6 +534,43 @@ static int states_to_blob(void)
 
 	return UBUS_STATUS_OK;
 }
+
+static int ubus_handle_get_stats(struct ubus_context *ctx, _unused struct ubus_object *obj,
+		struct ubus_request_data *req, _unused const char *method,
+		_unused struct blob_attr *msg)
+{
+	struct dhcpv6_stats stats = dhcpv6_get_stats();
+
+	blob_buf_init(&b, BLOBMSG_TYPE_TABLE);
+	blobmsg_add_u64(&b, "dhcp_solicit", stats.solicit);
+	blobmsg_add_u64(&b, "dhcp_advertise", stats.advertise);
+	blobmsg_add_u64(&b, "dhcp_request", stats.request);
+	blobmsg_add_u64(&b, "dhcp_confirm", stats.confirm);
+	blobmsg_add_u64(&b, "dhcp_renew", stats.renew);
+	blobmsg_add_u64(&b, "dhcp_rebind", stats.rebind);
+	blobmsg_add_u64(&b, "dhcp_reply", stats.reply);
+	blobmsg_add_u64(&b, "dhcp_release", stats.release);
+	blobmsg_add_u64(&b, "dhcp_decline", stats.decline);
+	blobmsg_add_u64(&b, "dhcp_reconfigure", stats.reconfigure);
+	blobmsg_add_u64(&b, "dhcp_information_request", stats.information_request);
+	blobmsg_add_u64(&b, "dhcp_discarded_packets", stats.discarded_packets);
+	blobmsg_add_u64(&b, "dhcp_transmit_failures", stats.transmit_failures);
+
+	CHECK(ubus_send_reply(ctx, req, b.head));
+	blob_buf_free(&b);
+
+	return UBUS_STATUS_OK;
+}
+
+static int ubus_handle_reset_stats(_unused struct ubus_context *ctx, _unused struct ubus_object *obj,
+		_unused struct ubus_request_data *req, _unused const char *method,
+		_unused struct blob_attr *msg)
+{
+	dhcpv6_reset_stats();
+
+	return UBUS_STATUS_OK;
+}
+
 
 static int ubus_handle_get_state(struct ubus_context *ctx, _unused struct ubus_object *obj,
 		struct ubus_request_data *req, _unused const char *method,

--- a/src/ubus.h
+++ b/src/ubus.h
@@ -66,5 +66,6 @@
 char *ubus_init(const char* interface);
 struct ubus_context *ubus_get_ctx(void);
 void ubus_destroy(struct ubus_context *ubus); 
+int ubus_dhcp_event(const char *status);
 
 #endif

--- a/src/ubus.h
+++ b/src/ubus.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+**
+** SPDX-License-Identifier: BSD-2-Clause-Patent
+**
+** SPDX-FileCopyrightText: Copyright (c) 2024 SoftAtHome
+**
+** Redistribution and use in source and binary forms, with or
+** without modification, are permitted provided that the following
+** conditions are met:
+**
+** 1. Redistributions of source code must retain the above copyright
+** notice, this list of conditions and the following disclaimer.
+**
+** 2. Redistributions in binary form must reproduce the above
+** copyright notice, this list of conditions and the following
+** disclaimer in the documentation and/or other materials provided
+** with the distribution.
+**
+** Subject to the terms and conditions of this license, each
+** copyright holder and contributor hereby grants to those receiving
+** rights under this license a perpetual, worldwide, non-exclusive,
+** no-charge, royalty-free, irrevocable (except for failure to
+** satisfy the conditions of this license) patent license to make,
+** have made, use, offer to sell, sell, import, and otherwise
+** transfer this software, where such license applies only to those
+** patent claims, already acquired or hereafter acquired, licensable
+** by such copyright holder or contributor that are necessarily
+** infringed by:
+**
+** (a) their Contribution(s) (the licensed copyrights of copyright
+** holders and non-copyrightable additions of contributors, in
+** source or binary form) alone; or
+**
+** (b) combination of their Contribution(s) with the work of
+** authorship to which such Contribution(s) was added by such
+** copyright holder or contributor, if, at the time the Contribution
+** is added, such addition causes such combination to be necessarily
+** infringed. The patent license shall not apply to any other
+** combinations which include the Contribution.
+**
+** Except as expressly stated above, no rights or licenses from any
+** copyright holder or contributor is granted under this license,
+** whether expressly, by implication, estoppel or otherwise.
+**
+** DISCLAIMER
+**
+** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+** CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+** INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+** MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR
+** CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+** SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+** LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+** USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+** AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+** LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+** ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+** POSSIBILITY OF SUCH DAMAGE.
+**
+****************************************************************************/
+
+#ifndef _UBUS_H__
+#define _UBUS_H__
+
+char *ubus_init(const char* interface);
+struct ubus_context *ubus_get_ctx(void);
+void ubus_destroy(struct ubus_context *ubus); 
+
+#endif


### PR DESCRIPTION
The following features have been added :
- Sending/Receiving DHCPv6 messages is handled asynchronously
- Connection to the ubus backend can be enabled by compiling with the flag`ENABLE_UBUS`
- DHCPv6 state changes triggers ubus event to use instead of the shell script call
- Ubus methods :
   - to get the DHCPv6 states data
   - to get the DHCPv6 packets statistics
   - to reconfigure and reset odhcp6c without restarting the process
   - to renew/release DHCPv6 (instead of using signals)
- Retransmission parameter fully configurable and update the default value based on RFC8815 
- Option to set the DSCP value for transmitted DHCPv6 packets via start args or ubus reconfiguration
- Configuration Token protocol for reconfigure message